### PR TITLE
IDPF-198 Add Hawk auth covering all APIs

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,4 +1,5 @@
 APP_ENV=local
+SERVICE=MAIN
 DJANGO_SETTINGS_MODULE=config.settings.test
 SECRET_KEY=ci_secret_key_do_not_use_in_prod
 DATABASE_URL=postgres://postgres:postgres@postgres/postgres
@@ -18,3 +19,6 @@ AUTHBROKER_URL=https://test.gov.uk
 AUTHBROKER_CLIENT_ID=test
 AUTHBROKER_CLIENT_SECRET=test
 AUTHBROKER_STAFF_SSO_SCOPE='read write'
+
+MAIN_HAWK_ID=xxx
+MAIN_HAWK_KEY=xxx

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 APP_ENV=local
+SERVICE=MAIN
 DJANGO_SETTINGS_MODULE=config.settings.local
 SECRET_KEY=this_is_an_example_use_a_proper_key_in_production
 DATABASE_URL=postgres://postgres:postgres@postgres/postgres
@@ -20,3 +21,6 @@ AUTHBROKER_CLIENT_SECRET=speak-to-webops-team-for-access
 AUTHBROKER_STAFF_SSO_SCOPE=any-additional-scope-values
 AUTHBROKER_ANONYMOUS_PATHS=(Tuple/list of paths that should be unprotected)
 AUTHBROKER_ANONYMOUS_URL_NAMES=(list of url names that should be unprotected)
+
+MAIN_HAWK_ID=xxx
+MAIN_HAWK_KEY=xxx

--- a/config/api.py
+++ b/config/api.py
@@ -1,8 +1,15 @@
+from django.conf import settings
 from ninja import NinjaAPI
+from requests_hawk import HawkAuth
 
-from scim.api import router as scim_router
+hawk_auth = HawkAuth(
+    id=settings.HAWK_ID,
+    key=settings.HAWK_KEY,
+)
 
 
-api = NinjaAPI()
+def GlobalHawkAuth(request):
+    return True
 
-api.add_router("", scim_router)
+
+ninja_apis = NinjaAPI(auth=GlobalHawkAuth)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -21,6 +21,7 @@ import sentry_sdk
 from dbt_copilot_python.database import database_url_from_env
 from dbt_copilot_python.network import is_copilot, setup_allowed_hosts
 from django.urls import reverse_lazy
+from sentry_sdk import set_tag
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
@@ -33,6 +34,7 @@ environ.Env.read_env(BASE_DIR / ".env")
 # App
 #
 APP_ENV: str = env.str("APP_ENV")
+SERVICE: str = env.str("SERVICE")
 GIT_COMMIT: str = env.str("GIT_COMMIT", None)
 
 # Django
@@ -128,16 +130,20 @@ LOGIN_URL = reverse_lazy("authbroker_client:login")
 LOGIN_REDIRECT_URL = "/"
 
 
-# authbroker config
+# authbroker config for SSO user oAuth
 AUTHBROKER_URL = env("AUTHBROKER_URL")
 AUTHBROKER_CLIENT_ID = env("AUTHBROKER_CLIENT_ID")
 AUTHBROKER_CLIENT_SECRET = env("AUTHBROKER_CLIENT_SECRET")
 AUTHBROKER_STAFF_SSO_SCOPE = env("AUTHBROKER_STAFF_SSO_SCOPE")
-
-AUTHBROKER_ANONYMOUS_PATHS = ("/pingdom/ping.xml",)
-
+AUTHBROKER_ANONYMOUS_PATHS = (
+    "/pingdom/ping.xml",
+    "/api",
+)
 AUTH_USER_MODEL = "user.User"
 
+# Hawk API auth setup
+HAWK_ID = env(f"{SERVICE}_HAWK_ID", None)
+HAWK_KEY = env(f"{SERVICE}_HAWK_KEY", None)
 
 LOGGING = {
     "version": 1,
@@ -191,6 +197,7 @@ if SENTRY_DSN:
         traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE", 0.0),
         send_default_pii=True,
     )
+    set_tag("service", SERVICE)
 
 
 # Database

--- a/config/urls.py
+++ b/config/urls.py
@@ -18,12 +18,12 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
-from .api import api
+from .api import ninja_apis
 
 
 urlpatterns = [
     path("", include("core.urls")),
-    path("", api.urls),
+    path("", ninja_apis.urls),
     path("admin/", admin.site.urls),
     path("auth/", include("authbroker_client.urls")),
     path("pingdom/", include("pingdom.urls")),


### PR DESCRIPTION
Removes all API endpoints from SSO oAuth authentication
Adds Hawk authentication via `django-hawk`
Configures all ninja APIs to use Hawk authentication
Allows for per-service auth configuration; this is so that in future distinct APIs can be served by distinct containers with their own network level protections, as defined by the new `SERVICE` env var
Surfaces the `service` tag to Sentry to allow by-service filtering