### PR TITLE
IDPF-249 OAuth incorrectly being applied to API endpoints

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -108,10 +108,14 @@ MIDDLEWARE: list[str] = [
 ]
 
 if INFRA_SERVICE == "MAIN":
-    MIDDLEWARE.append("authbroker_client.middleware.ProtectAllViewsMiddleware",)
+    MIDDLEWARE.append(
+        "authbroker_client.middleware.ProtectAllViewsMiddleware",
+    )
 
 # Keep the order of Middleware, history is last.
-MIDDLEWARE.append("simple_history.middleware.HistoryRequestMiddleware",)
+MIDDLEWARE.append(
+    "simple_history.middleware.HistoryRequestMiddleware",
+)
 
 TEMPLATES: list[dict[str, Any]] = [
     {

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -105,9 +105,13 @@ MIDDLEWARE: list[str] = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "authbroker_client.middleware.ProtectAllViewsMiddleware",
-    "simple_history.middleware.HistoryRequestMiddleware",
 ]
+
+if INFRA_SERVICE == "MAIN":
+    MIDDLEWARE.append("authbroker_client.middleware.ProtectAllViewsMiddleware",)
+
+# Keep the order of Middleware, history is last.
+MIDDLEWARE.append("simple_history.middleware.HistoryRequestMiddleware",)
 
 TEMPLATES: list[dict[str, Any]] = [
     {


### PR DESCRIPTION
OAuth is being applied to API endpoints incorrectly, this is due to the fact that request paths are trimmed by the load balancer and all `/api` requests are being treated as `/` instead, causing OAuth to trigger.

This fix means OAuth is only applied on the `MAIN` InfaService which separates out `/` for views and `/api` for API endpoints correctly.