### PR TITLE
IDPF-271 Disable Redis Cache

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -293,13 +293,14 @@ if is_copilot():
 else:
     IDENTITY_REDIS_URL = IDENTITY_REDIS
 
-CACHES: dict[str, Any] = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": IDENTITY_REDIS_URL,
-        "KEY_PREFIX": "wp_",
-    }
-}
+# Disabled as Ninja calls shouldn't be cached.
+# CACHES: dict[str, Any] = {
+#     "default": {
+#         "BACKEND": "django.core.cache.backends.redis.RedisCache",
+#         "LOCATION": IDENTITY_REDIS_URL,
+#         "KEY_PREFIX": "identity_",
+#     }
+# }
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.1/topics/i18n/


### PR DESCRIPTION
Having caching on is causing ssl errors in staging, and after some consideration I'm not sure we should be caching full stop as a API.
Staff SSO does not do any caching and i'm wondering around why/if we should be caching user sessions, api calls etc, and what this means from a security perspective?