### PR TITLE
IDPF-292 Add emails field to ProfileMinimal

### DIFF
--- a/core/schemas/profiles.py
+++ b/core/schemas/profiles.py
@@ -13,4 +13,5 @@ class ProfileMinimal(ModelSchema):
             "last_name",
             "primary_email",
             "contact_email",
+            "emails",
         ]


### PR DESCRIPTION
To get and return emails from identity_profile as "`related_emails`" on the staff-sso side, we need to have the `emails` field in the `ProfileMinimal`.
