### PR TITLE
IDPF-275 Enable creation of inactive users via sso

### DIFF
--- a/core/api/main.py
+++ b/core/api/main.py
@@ -22,7 +22,7 @@ router.add_router("identity", identity_router)
 def get_user(request, id: str):
     """Just a demo, do not build against this."""
     try:
-        return core_services.get_active_profile_by_id(id)
+        return core_services.get_identity_by_id(id=id)
     except Profile.DoesNotExist:
         return 404, {
             "message": "Unable to find user",

--- a/core/api/main.py
+++ b/core/api/main.py
@@ -22,7 +22,7 @@ router.add_router("identity", identity_router)
 def get_user(request, id: str):
     """Just a demo, do not build against this."""
     try:
-        return core_services.get_by_id(id)
+        return core_services.get_active_profile_by_id(id)
     except Profile.DoesNotExist:
         return 404, {
             "message": "Unable to find user",

--- a/core/api/people_finder.py
+++ b/core/api/people_finder.py
@@ -22,7 +22,7 @@ router.add_router("person", profile_router)
 def get_user(request, id: str):
     """Just a demo, do not build against this"""
     try:
-        return core_services.get_by_id(id)
+        return core_services.get_active_profile_by_id(id)
     except Profile.DoesNotExist:
         return 404, {
             "message": "Unable to find user",

--- a/core/api/people_finder.py
+++ b/core/api/people_finder.py
@@ -22,7 +22,7 @@ router.add_router("person", profile_router)
 def get_user(request, id: str):
     """Just a demo, do not build against this"""
     try:
-        return core_services.get_active_profile_by_id(id)
+        return core_services.get_identity_by_id(id=id)
     except Profile.DoesNotExist:
         return 404, {
             "message": "Unable to find user",

--- a/core/api/scim.py
+++ b/core/api/scim.py
@@ -45,11 +45,6 @@ def get_user(request, id: str):
 )
 def create_user(request, scim_user: CreateUserRequest) -> tuple[int, User | dict]:
     """Creates the given Identity record; will not update"""
-    if not scim_user.active:
-        return 400, {
-            "status": "400",
-            "detail": "Cannot create inactive user via SCIM",
-        }
 
     if not scim_user.emails:
         return 400, {
@@ -67,6 +62,7 @@ def create_user(request, scim_user: CreateUserRequest) -> tuple[int, User | dict
             all_emails=emails,
             primary_email=scim_user.get_primary_email(),
             contact_email=scim_user.get_contact_email(),
+            is_active=scim_user.active,
         )
         return 201, user
 

--- a/core/api/scim.py
+++ b/core/api/scim.py
@@ -27,7 +27,7 @@ router = Router()
 def get_user(request, id: str):
     """Returns the Identity record (internally: Profile) with the given ID"""
     try:
-        return core_services.get_by_id(id)
+        return core_services.get_identity_by_id(id=id, include_inactive=True)
     except Profile.DoesNotExist:
         return 404, {
             "status": "404",
@@ -92,7 +92,7 @@ def update_user(
         primary_email = scim_user.get_primary_email()
         contact_email = scim_user.get_contact_email()
 
-        profile = core_services.get_by_id(id=id)
+        profile = core_services.get_identity_by_id(id=id, include_inactive=True)
 
         core_services.update_identity(
             profile=profile,
@@ -118,7 +118,7 @@ def delete_user(
 ) -> int | tuple[int, dict]:
     """Deleted the Identity record with the given ID"""
     try:
-        profile = core_services.get_by_id(id=id)
+        profile = core_services.get_identity_by_id(id=id, include_inactive=True)
         core_services.delete_identity(
             profile=profile,
         )

--- a/core/api/sso_profile.py
+++ b/core/api/sso_profile.py
@@ -19,7 +19,7 @@ router = Router()
 def get_user(request, id: str):
     """Optimised, low-flexibility endpoint to return a minimal Identity record (internally: Profile)"""
     try:
-        return core_services.get_by_id(id)
+        return core_services.get_active_profile_by_id(id)
     except Profile.DoesNotExist:
         return 404, {
             "message": "Unable to find user",

--- a/core/api/sso_profile.py
+++ b/core/api/sso_profile.py
@@ -19,7 +19,7 @@ router = Router()
 def get_user(request, id: str):
     """Optimised, low-flexibility endpoint to return a minimal Identity record (internally: Profile)"""
     try:
-        return core_services.get_active_profile_by_id(id)
+        return core_services.get_identity_by_id(id=id)
     except Profile.DoesNotExist:
         return 404, {
             "message": "Unable to find user",

--- a/core/management/commands/create_identity_fixture.py
+++ b/core/management/commands/create_identity_fixture.py
@@ -32,6 +32,7 @@ class Command(BaseCommand):
         last_name = kwargs["last_name"]
         staff = kwargs["staff"]
         superuser = kwargs["superuser"]
+        is_active = kwargs["is_active"]
         dry_run = kwargs["dry_run"]
 
         factory_faker = faker.Faker()
@@ -50,6 +51,9 @@ class Command(BaseCommand):
         if last_name is None:
             last_name = factory_faker.last_name()
 
+        if is_active is None:
+            is_active = factory_faker.is_active()
+
         self.stdout.write(
             f"Creating user with id: {sso_email_id}, email: {email}, first_name: {first_name} and last_name: {last_name}"
         )
@@ -62,6 +66,7 @@ class Command(BaseCommand):
             first_name=first_name,
             last_name=last_name,
             all_emails=[email],
+            is_active=is_active,
         )
 
         if superuser:

--- a/core/services.py
+++ b/core/services.py
@@ -145,13 +145,7 @@ def bulk_create_and_update_identity_users_from_sso(
     Creates and updates existing Staff SSO users in the Identity database
     """
     id_user_ids = User.objects.all().values_list("sso_email_id", flat=True)
-    is_active = None
     for sso_user in sso_users:
-        if sso_user[SSO_USER_STATUS] == "active":
-            is_active = True
-        else:
-            is_active = False
-
         if sso_user[SSO_USER_EMAIL_ID] not in id_user_ids:
             primary_email, contact_email, all_emails = extract_emails_from_sso_user(
                 sso_user
@@ -161,7 +155,7 @@ def bulk_create_and_update_identity_users_from_sso(
                 first_name=sso_user[SSO_FIRST_NAME],
                 last_name=sso_user[SSO_LAST_NAME],
                 all_emails=all_emails,
-                is_active=is_active,
+                is_active=sso_user[SSO_USER_STATUS] == "active",
                 primary_email=primary_email,
                 contact_email=contact_email,
             )

--- a/core/services.py
+++ b/core/services.py
@@ -175,9 +175,8 @@ def bulk_create_and_update_identity_users_from_sso(
                 primary_email=primary_email,
                 contact_email=contact_email,
             )
-    else:
         # if inactive sso user is currently active in ID, they should be archived
-        if sso_user[SSO_USER_EMAIL_ID] in id_user_ids:
+        if sso_user[SSO_USER_EMAIL_ID] in id_user_ids and sso_user[SSO_USER_STATUS] == "inactive":
             user = User.objects.get(sso_email_id=sso_user[SSO_USER_EMAIL_ID])
             if user.is_active:
                 user_services.archive(user)

--- a/core/services.py
+++ b/core/services.py
@@ -176,7 +176,10 @@ def bulk_create_and_update_identity_users_from_sso(
                 contact_email=contact_email,
             )
         # if inactive sso user is currently active in ID, they should be archived
-        if sso_user[SSO_USER_EMAIL_ID] in id_user_ids and sso_user[SSO_USER_STATUS] == "inactive":
+        if (
+            sso_user[SSO_USER_EMAIL_ID] in id_user_ids
+            and sso_user[SSO_USER_STATUS] == "inactive"
+        ):
             user = User.objects.get(sso_email_id=sso_user[SSO_USER_EMAIL_ID])
             if user.is_active:
                 user_services.archive(user)

--- a/core/services.py
+++ b/core/services.py
@@ -176,14 +176,11 @@ def bulk_create_and_update_identity_users_from_sso(
                 primary_email=primary_email,
                 contact_email=contact_email,
             )
-        # if inactive sso user is currently active in ID, they should be archived
-        if (
-            sso_user[SSO_USER_EMAIL_ID] in id_user_ids
-            and sso_user[SSO_USER_STATUS] == "inactive"
-        ):
-            user = User.objects.get(sso_email_id=sso_user[SSO_USER_EMAIL_ID])
-            if user.is_active:
-                user_services.archive(user)
+            # if inactive sso user is currently active in ID, they should be archived
+            if sso_user[SSO_USER_STATUS] == "inactive":
+                user = User.objects.get(sso_email_id=sso_user[SSO_USER_EMAIL_ID])
+                if user.is_active:
+                    user_services.archive(user)
 
 
 def extract_emails_from_sso_user(sso_user) -> tuple[str, str, list[str]]:

--- a/core/services.py
+++ b/core/services.py
@@ -29,6 +29,10 @@ def get_by_id(id: str):
     return profile_services.get_by_id(sso_email_id=id)
 
 
+def get_active_profile_by_id(sso_email_id: str) -> Profile:
+    return profile_services.get_active_profile_by_id(sso_email_id)
+
+
 def create_identity(
     id: str,
     first_name: str,
@@ -71,6 +75,13 @@ def update_identity(
     Function for updating an existing user (archive / unarchive) and their profile information.
     """
 
+    user = User.objects.get(sso_email_id=profile.sso_email_id)
+    if user.is_active != is_active:
+        if user.is_active == False:
+            user_services.unarchive(user)
+        else:
+            user_services.archive(user)
+
     profile_services.update_from_sso(
         profile=profile,
         first_name=first_name,
@@ -79,13 +90,6 @@ def update_identity(
         primary_email=primary_email,
         contact_email=contact_email,
     )
-
-    user = User.objects.get(sso_email_id=profile.sso_email_id)
-    if user.is_active != is_active:
-        if is_active:
-            user_services.unarchive(user)
-        else:
-            user_services.archive(user)
 
 
 def delete_identity(profile: Profile) -> None:

--- a/core/services.py
+++ b/core/services.py
@@ -29,8 +29,8 @@ def get_by_id(id: str):
     return profile_services.get_by_id(sso_email_id=id)
 
 
-def get_active_profile_by_id(sso_email_id: str) -> Profile:
-    return profile_services.get_active_profile_by_id(sso_email_id)
+def get_active_profile_by_id(id: str) -> Profile:
+    return profile_services.get_active_profile_by_id(sso_email_id=id)
 
 
 def create_identity(

--- a/core/tests/test_services.py
+++ b/core/tests/test_services.py
@@ -28,7 +28,7 @@ def test_create_identity(mocker):
     )
     # User is created
     profile = services.create_identity(
-        id="john.sso.email.id@gov.uk",
+        id="billy.sso.email.id@gov.uk",
         first_name="Billy",
         last_name="Bob",
         all_emails=[
@@ -36,14 +36,16 @@ def test_create_identity(mocker):
             "test2@test.com",
             "test3@test.com",
         ],
+        is_active=False,
         primary_email="test2@test.com",
         contact_email="test3@test.com",
     )
     mock_user_create.assert_called_once_with(
-        sso_email_id="john.sso.email.id@gov.uk",
+        sso_email_id="billy.sso.email.id@gov.uk",
+        is_active=False,
     )
     mock_profiles_create.assert_called_once_with(
-        sso_email_id="john.sso.email.id@gov.uk",
+        sso_email_id="billy.sso.email.id@gov.uk",
         first_name="Billy",
         last_name="Bob",
         all_emails=[
@@ -64,6 +66,7 @@ def test_existing_user(basic_user) -> None:
             first_name="Billy",
             last_name="Bob",
             all_emails=["new_user@email.gov.uk"],
+            is_active=True,
         )
 
 
@@ -73,6 +76,7 @@ def test_new_user() -> None:
         first_name="Billy",
         last_name="Bob",
         all_emails=["new_user@email.gov.uk"],
+        is_active=True,
     )
     assert isinstance(profile, Profile)
     assert profile.pk
@@ -86,6 +90,7 @@ def test_update_identity() -> None:
         "Billy",
         "Bob",
         ["new_user@email.gov.uk"],
+        is_active=True,
     )
     assert User.objects.get(sso_email_id="new_user@gov.uk").is_active
 
@@ -109,6 +114,7 @@ def test_delete_identity() -> None:
         "Billy",
         "Bob",
         ["new_user@email.gov.uk"],
+        is_active=True,
     )
 
     services.delete_identity(
@@ -135,12 +141,14 @@ def test_bulk_delete_identity_users_from_sso(mocker) -> None:
         first_name="Billy",
         last_name="Bob",
         all_emails=["new_user@email.gov.uk"],
+        is_active=True,
     )
     services.create_identity(
         id="sso_user2@gov.uk",
         first_name="Gilly",
         last_name="Bob",
         all_emails=["user@email.gov.uk"],
+        is_active=True,
     )
 
     mock_delete_identity = mocker.patch(
@@ -152,7 +160,7 @@ def test_bulk_delete_identity_users_from_sso(mocker) -> None:
             SSO_USER_EMAIL_ID: "sso_user2@gov.uk",
             SSO_FIRST_NAME: "Gilly",
             SSO_LAST_NAME: "Bob",
-            SSO_USER_STATUS: "active",
+            SSO_USER_STATUS: "inactive",
             SSO_EMAIL_ADDRESSES: ["sso_user2@gov.uk"],
             SSO_CONTACT_EMAIL_ADDRESS: "user2@gov.uk",
         },
@@ -173,6 +181,7 @@ def test_bulk_create_and_update_identity_users_from_sso(mocker) -> None:
         first_name="Gilly",
         last_name="Bob",
         all_emails=["user@email.gov.uk"],
+        is_active=True,
     )
     mock_create_identity = mocker.patch(
         "core.services.create_identity", return_value="__profile__"
@@ -194,7 +203,7 @@ def test_bulk_create_and_update_identity_users_from_sso(mocker) -> None:
             SSO_USER_EMAIL_ID: "sso_user3@gov.uk",
             SSO_FIRST_NAME: "Alice",
             SSO_LAST_NAME: "Smith",
-            SSO_USER_STATUS: "active",
+            SSO_USER_STATUS: "inactive",
             SSO_EMAIL_ADDRESSES: ["sso_user3@gov.uk"],
             SSO_CONTACT_EMAIL_ADDRESS: "user3@gov.uk",
         },
@@ -205,6 +214,7 @@ def test_bulk_create_and_update_identity_users_from_sso(mocker) -> None:
         first_name="Alice",
         last_name="Smith",
         all_emails=["sso_user3@gov.uk", "user3@gov.uk"],
+        is_active=False,
         primary_email="sso_user3@gov.uk",
         contact_email="user3@gov.uk",
     )
@@ -225,12 +235,14 @@ def test_sync_bulk_sso_users(mocker) -> None:
         first_name="Billy",
         last_name="Bob",
         all_emails=["new_user@email.gov.uk"],
+        is_active=True,
     )
     services.create_identity(
         id="sso_user2@gov.uk",
         first_name="Gilly",
         last_name="Bob",
         all_emails=["user@email.gov.uk"],
+        is_active=True,
     )
 
     mock_get_bulk_user_records = mocker.patch(

--- a/core/tests/test_services.py
+++ b/core/tests/test_services.py
@@ -121,8 +121,9 @@ def test_delete_identity() -> None:
         profile,
     )
     with pytest.raises(Profile.DoesNotExist) as pex:
-        services.get_by_id(
+        services.get_identity_by_id(
             id=profile.sso_email_id,
+            include_inactive=True,
         )
 
     assert str(pex.value.args[0]) == "Profile matching query does not exist."
@@ -166,8 +167,10 @@ def test_bulk_delete_identity_users_from_sso(mocker) -> None:
         },
     ]
 
-    profile1_to_delete = services.get_by_id("sso_email_id@email.com")
-    profile2_to_delete = services.get_by_id(id)
+    profile1_to_delete = services.get_identity_by_id(
+        "sso_email_id@email.com", include_inactive=True
+    )
+    profile2_to_delete = services.get_identity_by_id(id, include_inactive=True)
     calls = [call(profile=profile1_to_delete), call(profile=profile2_to_delete)]
 
     services.bulk_delete_identity_users_from_sso(sso_users=sso_users)
@@ -219,7 +222,9 @@ def test_bulk_create_and_update_identity_users_from_sso(mocker) -> None:
         contact_email="user3@gov.uk",
     )
     mock_update_identity.assert_called_once_with(
-        profile=services.get_by_id("sso_user2@gov.uk"),
+        profile=services.get_identity_by_id(
+            id="sso_user2@gov.uk", include_inactive=True
+        ),
         first_name="Jane",
         last_name="Doe",
         all_emails=["sso_user2@gov.uk", "user2@gov.uk"],

--- a/e2e_tests/test_scim.py
+++ b/e2e_tests/test_scim.py
@@ -21,7 +21,7 @@ def test_create(scim_user_factory):
     url = reverse("scim:create_user")
 
     with pytest.raises(Profile.DoesNotExist):
-        services.get_by_id(scim_user_dict["id"])
+        services.get_identity_by_id(scim_user_dict["id"], include_inactive=True)
 
     response = client.post(
         url,
@@ -30,7 +30,7 @@ def test_create(scim_user_factory):
     )
 
     assert response.status_code == 201
-    profile = services.get_by_id(scim_user_dict["id"])
+    profile = services.get_identity_by_id(scim_user_dict["id"], include_inactive=True)
     assert profile.first_name == scim_user_dict["name"]["givenName"]
     assert profile.last_name == scim_user_dict["name"]["familyName"]
     assert len(profile.emails) == len(scim_user_dict["emails"])

--- a/profiles/services/__init__.py
+++ b/profiles/services/__init__.py
@@ -9,12 +9,13 @@ from profiles.services import combined, staff_sso
 from profiles.types import Unset
 
 
-def get_by_id(sso_email_id: str) -> Profile:
-    return combined.get_by_id(sso_email_id=sso_email_id)
-
-
-def get_active_profile_by_id(sso_email_id: str) -> Profile:
-    return combined.get_active_profile_by_id(sso_email_id=sso_email_id)
+def get_by_id(sso_email_id: str, include_inactive: bool = False) -> Profile:
+    """
+    Retrieve a profile by its User ID.
+    """
+    return combined.get_by_id(
+        sso_email_id=sso_email_id, include_inactive=include_inactive
+    )
 
 
 def generate_combined_profile_data(sso_email_id: str):
@@ -23,7 +24,7 @@ def generate_combined_profile_data(sso_email_id: str):
     field hierarchy per data type to generate the values for the combined.
     create method
     """
-    sso_profile = staff_sso.get_by_id(sso_email_id=sso_email_id)
+    sso_profile = staff_sso.get_by_id(sso_email_id=sso_email_id, include_inactive=True)
     user = sso_profile.user
 
     primary_email = sso_profile.primary_email
@@ -83,7 +84,9 @@ def update_from_sso(
     primary_email: str | Unset | None = None,
     contact_email: str | Unset | None = None,
 ) -> None:
-    sso_profile = staff_sso.get_by_id(profile.sso_email_id)
+    sso_profile = staff_sso.get_by_id(
+        sso_email_id=profile.sso_email_id, include_inactive=True
+    )
     staff_sso.update(
         staff_sso_profile=sso_profile,
         first_name=first_name,
@@ -93,7 +96,9 @@ def update_from_sso(
         contact_email=contact_email,
     )
 
-    combined_profile = combined.get_by_id(sso_email_id=profile.sso_email_id)
+    combined_profile = combined.get_by_id(
+        sso_email_id=profile.sso_email_id, include_inactive=True
+    )
     combined_profile_data = generate_combined_profile_data(
         sso_email_id=profile.sso_email_id
     )
@@ -110,26 +115,32 @@ def update_from_sso(
 
 
 def delete_from_sso(profile: Profile) -> None:
-    sso_profile = staff_sso.get_by_id(profile.sso_email_id)
+    sso_profile = staff_sso.get_by_id(profile.sso_email_id, include_inactive=True)
     staff_sso.delete_from_database(sso_profile=sso_profile)
 
     all_profiles = get_all_profiles(sso_email_id=profile.sso_email_id)
 
     # check if combined profile is the only profile left for user
     if [key for key in all_profiles] == ["combined"]:
-        combined_profile = combined.get_by_id(sso_email_id=profile.sso_email_id)
+        combined_profile = combined.get_by_id(
+            sso_email_id=profile.sso_email_id, include_inactive=True
+        )
         combined.delete_from_database(profile=combined_profile)
 
 
 def get_all_profiles(sso_email_id: str) -> dict[str, models.Model]:
     all_profile = dict()
     try:
-        all_profile["combined"] = combined.get_by_id(sso_email_id=sso_email_id)
+        all_profile["combined"] = combined.get_by_id(
+            sso_email_id=sso_email_id, include_inactive=True
+        )
     except:
         # no combined profile found
         pass
     try:
-        all_profile["sso"] = staff_sso.get_by_id(sso_email_id=sso_email_id)
+        all_profile["sso"] = staff_sso.get_by_id(
+            sso_email_id=sso_email_id, include_inactive=True
+        )
     except:
         # no sso profile found
         pass

--- a/profiles/services/__init__.py
+++ b/profiles/services/__init__.py
@@ -8,11 +8,13 @@ from profiles.models.combined import Profile
 from profiles.services import combined, staff_sso
 from profiles.types import Unset
 
-from .combined import get_by_id as get_combined_by_id
-
 
 def get_by_id(sso_email_id: str) -> Profile:
-    return get_combined_by_id(sso_email_id=sso_email_id)
+    return combined.get_by_id(sso_email_id=sso_email_id)
+
+
+def get_active_profile_by_id(sso_email_id: str) -> Profile:
+    return combined.get_active_profile_by_id(sso_email_id=sso_email_id)
 
 
 def generate_combined_profile_data(sso_email_id: str):
@@ -69,6 +71,7 @@ def create_from_sso(
         primary_email=combined_profile_data["primary_email"],
         contact_email=combined_profile_data["contact_email"],
         all_emails=combined_profile_data["emails"],
+        is_active=combined_profile_data["is_active"],
     )
 
 
@@ -90,7 +93,7 @@ def update_from_sso(
         contact_email=contact_email,
     )
 
-    combined_profile = get_by_id(sso_email_id=profile.sso_email_id)
+    combined_profile = combined.get_by_id(sso_email_id=profile.sso_email_id)
     combined_profile_data = generate_combined_profile_data(
         sso_email_id=profile.sso_email_id
     )
@@ -101,8 +104,8 @@ def update_from_sso(
         last_name=combined_profile_data["last_name"],
         primary_email=combined_profile_data["primary_email"],
         contact_email=combined_profile_data["contact_email"],
-        is_active=combined_profile_data["is_active"],
         all_emails=combined_profile_data["emails"],
+        is_active=combined_profile_data["is_active"],
     )
 
 
@@ -114,14 +117,14 @@ def delete_from_sso(profile: Profile) -> None:
 
     # check if combined profile is the only profile left for user
     if [key for key in all_profiles] == ["combined"]:
-        combined_profile = get_by_id(sso_email_id=profile.sso_email_id)
+        combined_profile = combined.get_by_id(sso_email_id=profile.sso_email_id)
         combined.delete_from_database(profile=combined_profile)
 
 
 def get_all_profiles(sso_email_id: str) -> dict[str, models.Model]:
     all_profile = dict()
     try:
-        all_profile["combined"] = get_combined_by_id(sso_email_id=sso_email_id)
+        all_profile["combined"] = combined.get_by_id(sso_email_id=sso_email_id)
     except:
         # no combined profile found
         pass

--- a/profiles/services/combined.py
+++ b/profiles/services/combined.py
@@ -24,7 +24,7 @@ else:
 
 def get_by_id(sso_email_id: str) -> Profile:
     # NB we're not raising more specific exceptions here because we're optimising this for speed
-    return Profile.objects.get(sso_email_id=sso_email_id, is_active=True)
+    return Profile.objects.get(sso_email_id=sso_email_id)
 
 
 def create(

--- a/profiles/services/combined.py
+++ b/profiles/services/combined.py
@@ -22,14 +22,16 @@ else:
 #### ID is required - no getting around it ####
 
 
-def get_by_id(sso_email_id: str) -> Profile:
+def get_by_id(sso_email_id: str, include_inactive: bool = False) -> Profile:
+    """
+    Retrieve a profile by its User ID.
+    """
     # NB we're not raising more specific exceptions here because we're optimising this for speed
-    return Profile.objects.get(sso_email_id=sso_email_id)
-
-
-def get_active_profile_by_id(sso_email_id: str) -> Profile:
-    # NB we're not raising more specific exceptions here because we're optimising this for speed
-    return Profile.objects.get(sso_email_id=sso_email_id, is_active=True)
+    if include_inactive:
+        profile = Profile.objects.get(sso_email_id=sso_email_id)
+    else:
+        profile = Profile.objects.get(sso_email_id=sso_email_id, is_active=True)
+    return profile
 
 
 def create(
@@ -48,7 +50,7 @@ def create(
     in the list of emails if none is provided
     """
     try:
-        get_by_id(sso_email_id)
+        get_by_id(sso_email_id=sso_email_id, include_inactive=True)
     except Profile.DoesNotExist:
         profile = Profile.objects.create(
             sso_email_id=sso_email_id,

--- a/profiles/services/combined.py
+++ b/profiles/services/combined.py
@@ -28,10 +28,9 @@ def get_by_id(sso_email_id: str, include_inactive: bool = False) -> Profile:
     """
     # NB we're not raising more specific exceptions here because we're optimising this for speed
     if include_inactive:
-        profile = Profile.objects.get(sso_email_id=sso_email_id)
-    else:
-        profile = Profile.objects.get(sso_email_id=sso_email_id, is_active=True)
-    return profile
+        return Profile.objects.get(sso_email_id=sso_email_id)
+
+    return Profile.objects.get(sso_email_id=sso_email_id, is_active=True)
 
 
 def create(

--- a/profiles/services/combined.py
+++ b/profiles/services/combined.py
@@ -27,11 +27,17 @@ def get_by_id(sso_email_id: str) -> Profile:
     return Profile.objects.get(sso_email_id=sso_email_id)
 
 
+def get_active_profile_by_id(sso_email_id: str) -> Profile:
+    # NB we're not raising more specific exceptions here because we're optimising this for speed
+    return Profile.objects.get(sso_email_id=sso_email_id, is_active=True)
+
+
 def create(
     sso_email_id: str,
     first_name: str,
     last_name: str,
     all_emails: list[str],
+    is_active: bool,
     primary_email: Optional[str] = None,
     contact_email: Optional[str] = None,
     reason: Optional[str] = None,
@@ -51,7 +57,7 @@ def create(
             emails=all_emails,
             primary_email=primary_email,
             contact_email=contact_email,
-            is_active=True,
+            is_active=is_active,
         )
 
         if reason is None:

--- a/profiles/services/staff_sso.py
+++ b/profiles/services/staff_sso.py
@@ -26,12 +26,11 @@ def get_by_id(sso_email_id: str, include_inactive: bool = False) -> StaffSSOProf
     Retrieve a profile by its User ID.
     """
     if include_inactive:
-        sso_profile = StaffSSOProfile.objects.get(user__sso_email_id=sso_email_id)
-    else:
-        sso_profile = StaffSSOProfile.objects.get(
-            user__sso_email_id=sso_email_id, user__is_active=True
-        )
-    return sso_profile
+        return StaffSSOProfile.objects.get(user__sso_email_id=sso_email_id)
+
+    return StaffSSOProfile.objects.get(
+        user__sso_email_id=sso_email_id, user__is_active=True
+    )
 
 
 def create(

--- a/profiles/services/staff_sso.py
+++ b/profiles/services/staff_sso.py
@@ -23,6 +23,13 @@ else:
 
 def get_by_id(sso_email_id: str) -> StaffSSOProfile:
     """
+    Retrieve a profile by its User ID.
+    """
+    return StaffSSOProfile.objects.get(user__sso_email_id=sso_email_id)
+
+
+def get_active_sso_profile_by_id(sso_email_id: str) -> StaffSSOProfile:
+    """
     Retrieve a profile by its User ID, only if the user is not soft-deleted.
     """
     return StaffSSOProfile.objects.get(

--- a/profiles/services/staff_sso.py
+++ b/profiles/services/staff_sso.py
@@ -21,20 +21,17 @@ else:
 ###############################################################
 
 
-def get_by_id(sso_email_id: str) -> StaffSSOProfile:
+def get_by_id(sso_email_id: str, include_inactive: bool = False) -> StaffSSOProfile:
     """
     Retrieve a profile by its User ID.
     """
-    return StaffSSOProfile.objects.get(user__sso_email_id=sso_email_id)
-
-
-def get_active_sso_profile_by_id(sso_email_id: str) -> StaffSSOProfile:
-    """
-    Retrieve a profile by its User ID, only if the user is not soft-deleted.
-    """
-    return StaffSSOProfile.objects.get(
-        user__sso_email_id=sso_email_id, user__is_active=True
-    )
+    if include_inactive:
+        sso_profile = StaffSSOProfile.objects.get(user__sso_email_id=sso_email_id)
+    else:
+        sso_profile = StaffSSOProfile.objects.get(
+            user__sso_email_id=sso_email_id, user__is_active=True
+        )
+    return sso_profile
 
 
 def create(

--- a/profiles/tests/test_services_combined.py
+++ b/profiles/tests/test_services_combined.py
@@ -16,9 +16,8 @@ def test_get_by_id(combined_profile):
     # Get a soft-deleted profile
     soft_deleted_profile = combined_profile
     soft_deleted_profile.is_active = False
-   
+
     assert soft_deleted_profile == combined_profile
-    
 
     # or a non-existent one
     with pytest.raises(Profile.DoesNotExist) as ex:

--- a/profiles/tests/test_services_combined.py
+++ b/profiles/tests/test_services_combined.py
@@ -13,13 +13,12 @@ def test_get_by_id(combined_profile):
     get_profile_result = profile_services.get_by_id(combined_profile.sso_email_id)
     assert get_profile_result == combined_profile
 
-    # Try to get a soft-deleted profile
-    combined_profile.is_active = False
-    combined_profile.save()
-    with pytest.raises(Profile.DoesNotExist) as ex:
-        # no custom error to keep overheads low
-        profile_services.get_by_id(combined_profile.sso_email_id)
-        assert ex.value.args[0] == "User has been previously deleted"
+    # Get a soft-deleted profile
+    soft_deleted_profile = combined_profile
+    soft_deleted_profile.is_active = False
+   
+    assert soft_deleted_profile == combined_profile
+    
 
     # or a non-existent one
     with pytest.raises(Profile.DoesNotExist) as ex:

--- a/profiles/tests/test_services_combined.py
+++ b/profiles/tests/test_services_combined.py
@@ -10,16 +10,19 @@ pytestmark = pytest.mark.django_db
 
 
 def test_get_by_id(combined_profile):
+    # Get an active profile
     get_profile_result = profile_services.get_by_id(combined_profile.sso_email_id)
     assert get_profile_result == combined_profile
+    assert combined_profile.is_active == True
 
     # Get a soft-deleted profile
-    soft_deleted_profile = combined_profile
-    soft_deleted_profile.is_active = False
+    combined_profile.is_active = False
+    combined_profile.save()
 
-    assert soft_deleted_profile == combined_profile
+    soft_deleted_profile = profile_services.get_by_id(combined_profile.sso_email_id)
+    assert soft_deleted_profile.is_active == False
 
-    # or a non-existent one
+    # Try to get a non-existent profile
     with pytest.raises(Profile.DoesNotExist) as ex:
         profile_services.get_by_id("9999")
         assert str(ex.value.args[0]) == "User does not exist"

--- a/profiles/tests/test_services_combined.py
+++ b/profiles/tests/test_services_combined.py
@@ -15,38 +15,28 @@ def test_get_by_id(combined_profile):
     assert get_profile_result == combined_profile
     assert combined_profile.is_active == True
 
-    # Get a soft-deleted profile
+    # Get a soft-deleted profile when inactive profiles are included
     combined_profile.is_active = False
     combined_profile.save()
 
-    soft_deleted_profile = profile_services.get_by_id(combined_profile.sso_email_id)
+    soft_deleted_profile = profile_services.get_by_id(
+        combined_profile.sso_email_id, include_inactive=True
+    )
     assert soft_deleted_profile.is_active == False
 
-    # Try to get a non-existent profile
-    with pytest.raises(Profile.DoesNotExist) as ex:
-        profile_services.get_by_id("9999")
-        assert str(ex.value.args[0]) == "User does not exist"
-
-
-def test_get_active_profile_by_id(combined_profile):
-    # Get an active profile
-    get_profile_result = profile_services.get_active_profile_by_id(
-        combined_profile.sso_email_id
-    )
-    assert get_profile_result == combined_profile
-    assert combined_profile.is_active == True
-
-    # Try to get a soft-deleted profile
+    # Try to get a soft-deleted profile when inactive profiles are not included
     combined_profile.is_active = False
     combined_profile.save()
     with pytest.raises(Profile.DoesNotExist) as ex:
         # no custom error to keep overheads low
-        profile_services.get_active_profile_by_id(combined_profile.sso_email_id)
+        profile_services.get_by_id(
+            combined_profile.sso_email_id,
+        )
         assert ex.value.args[0] == "User has been previously deleted"
 
     # Try to get a non-existent profile
     with pytest.raises(Profile.DoesNotExist) as ex:
-        profile_services.get_active_profile_by_id("9999")
+        profile_services.get_by_id("9999")
         assert str(ex.value.args[0]) == "User does not exist"
 
 
@@ -161,7 +151,7 @@ def test_delete_from_database(combined_profile):
     combined_profile.refresh_from_db()
     profile_services.delete_from_database(combined_profile)
     with pytest.raises(combined_profile.DoesNotExist):
-        profile_services.get_by_id(combined_profile.sso_email_id)
+        profile_services.get_by_id(combined_profile.sso_email_id, include_inactive=True)
 
     assert LogEntry.objects.count() == 1
     log = LogEntry.objects.first()

--- a/profiles/tests/test_services_init.py
+++ b/profiles/tests/test_services_init.py
@@ -11,7 +11,9 @@ def test_get_by_id(mocker):
         "profiles.services.combined.get_by_id", return_value="__combined__"
     )
     result = services.get_by_id("sso_id")
-    mock_combined_get.assert_called_once_with(sso_email_id="sso_id")
+    mock_combined_get.assert_called_once_with(
+        sso_email_id="sso_id", include_inactive=False
+    )
     assert result == "__combined__"
 
 
@@ -19,7 +21,7 @@ def test_generate_combined_profile_data_accesses_profile_records(mocker):
     mock_sso_get = mocker.patch("profiles.services.staff_sso.get_by_id")
     mock_combined_get = mocker.patch("profiles.services.combined.get_by_id")
     services.generate_combined_profile_data(sso_email_id="sso_id")
-    mock_sso_get.assert_called_once_with(sso_email_id="sso_id")
+    mock_sso_get.assert_called_once_with(sso_email_id="sso_id", include_inactive=True)
     mock_combined_get.assert_not_called()
 
 

--- a/profiles/tests/test_services_init.py
+++ b/profiles/tests/test_services_init.py
@@ -8,9 +8,9 @@ pytestmark = pytest.mark.django_db
 
 def test_get_by_id(mocker):
     mock_combined_get = mocker.patch(
-        "profiles.services.get_by_id", return_value="__combined__"
+        "profiles.services.combined.get_by_id", return_value="__combined__"
     )
-    result = services.get_by_id(sso_email_id="sso_id")
+    result = services.get_by_id("sso_id")
     mock_combined_get.assert_called_once_with(sso_email_id="sso_id")
     assert result == "__combined__"
 

--- a/profiles/tests/test_services_init.py
+++ b/profiles/tests/test_services_init.py
@@ -8,9 +8,9 @@ pytestmark = pytest.mark.django_db
 
 def test_get_by_id(mocker):
     mock_combined_get = mocker.patch(
-        "profiles.services.get_combined_by_id", return_value="__combined__"
+        "profiles.services.get_by_id", return_value="__combined__"
     )
-    result = services.get_by_id("sso_id")
+    result = services.get_by_id(sso_email_id="sso_id")
     mock_combined_get.assert_called_once_with(sso_email_id="sso_id")
     assert result == "__combined__"
 
@@ -69,6 +69,7 @@ def test_create_from_sso(mocker):
         "primary_email": "julia@synth.tic",
         "contact_email": "kev@dco.gov.uk",
         "emails": ["a@b.io"],
+        "is_active": True,
     }
     mock_generate = mocker.patch(
         "profiles.services.generate_combined_profile_data",
@@ -102,6 +103,7 @@ def test_create_from_sso(mocker):
         first_name=mock_data["first_name"],
         last_name=mock_data["last_name"],
         all_emails=mock_data["emails"],
+        is_active=True,
         primary_email=mock_data["primary_email"],
         contact_email=mock_data["contact_email"],
     )

--- a/profiles/tests/test_services_staff_sso.py
+++ b/profiles/tests/test_services_staff_sso.py
@@ -15,35 +15,26 @@ def test_get_by_id(sso_profile):
     actual = staff_sso_services.get_by_id(sso_profile.user.pk)
     assert actual.user.sso_email_id == sso_profile.user.sso_email_id
 
-    # Get a soft-deleted profile
+    # Get a soft-deleted profile when inactive profiles are included
     sso_profile.user.is_active = False
     sso_profile.user.save()
 
-    soft_deleted_profile = staff_sso_services.get_by_id(sso_profile.user.pk)
+    soft_deleted_profile = staff_sso_services.get_by_id(
+        sso_profile.user.pk, include_inactive=True
+    )
     assert soft_deleted_profile.user.is_active == False
 
-    # Try to get a non-existent profile
-    with pytest.raises(StaffSSOProfile.DoesNotExist) as ex:
-        staff_sso_services.get_by_id("9999")
-        assert str(ex.value.args[0]) == "User does not exist"
-
-
-def test_get_active_profile_by_id(sso_profile):
-    # Get an active profile
-    actual = staff_sso_services.get_active_sso_profile_by_id(sso_profile.user.pk)
-    assert actual.user.sso_email_id == sso_profile.user.sso_email_id
-
-    # Try to get a soft-deleted profile
+    # Try to get a soft-deleted profile when inactive profiles are not included
     sso_profile.user.is_active = False
     sso_profile.user.save()
     with pytest.raises(StaffSSOProfile.DoesNotExist) as ex:
         # no custom error to keep overheads low
-        staff_sso_services.get_active_sso_profile_by_id(sso_profile.user.pk)
+        staff_sso_services.get_by_id(sso_profile.user.pk)
         assert ex.value.args[0] == "User has been previously deleted"
 
     # Try to get a non-existent profile
     with pytest.raises(StaffSSOProfile.DoesNotExist) as ex:
-        staff_sso_services.get_active_sso_profile_by_id("9999")
+        staff_sso_services.get_by_id("9999")
         assert str(ex.value.args[0]) == "User does not exist"
 
 

--- a/user/services.py
+++ b/user/services.py
@@ -38,6 +38,7 @@ def get_by_id(sso_email_id: str) -> User:
 
 def create(
     sso_email_id: str,
+    is_active: bool,
     is_staff: bool = False,
     is_superuser: bool = False,
     reason: Optional[str] = None,
@@ -49,7 +50,7 @@ def create(
     except User.DoesNotExist:
         user = User.objects.create_user(
             sso_email_id=sso_email_id,
-            is_active=True,
+            is_active=is_active,
             is_staff=is_staff,
             is_superuser=is_superuser,
         )

--- a/user/tests/test_service.py
+++ b/user/tests/test_service.py
@@ -32,6 +32,7 @@ def test_create():
     assert LogEntry.objects.count() == 0
     user = user_services.create(
         sso_email_id="sso_email_id_new_user@email.com",
+        is_active=True,
     )
 
     assert user.sso_email_id == "sso_email_id_new_user@email.com"
@@ -42,6 +43,7 @@ def test_create():
     with pytest.raises(UserExists) as ex:
         user_services.create(
             sso_email_id="sso_email_id_new_user@email.com",
+            is_active=True,
         )
         assert str(ex.value.args[0]) == "User has been previously created"
 


### PR DESCRIPTION
Staff SSO needs to be able to create inactive users in Identity, as these user records may be re-enabled at a later date.
- to get active and inactive user profiles we needed to update the `get_by_id` methods to enable returning all profiles.
- added a new argument `include_inactive` for get_by_id function, by default it will be `False` and if we want to include inactive identities we can set it to `True`

- [x] JIRA ticket referenced in title
- [x] Title is clear and concise
- [x] Description gives any relevant detail
- [x] Tests are up to date
- [x] Documentation is up to date
