### PR TITLE
IDPF-274 Refactor and handle partial records correctly in batch processes

### DIFF
--- a/core/api/main.py
+++ b/core/api/main.py
@@ -22,7 +22,7 @@ router.add_router("identity", identity_router)
 def get_user(request, id: str):
     """Just a demo, do not build against this."""
     try:
-        return core_services.get_identity_by_id(id=id)
+        return core_services.get_profile_by_id(id=id)
     except Profile.DoesNotExist:
         return 404, {
             "message": "Unable to find user",

--- a/core/api/people_finder.py
+++ b/core/api/people_finder.py
@@ -22,7 +22,7 @@ router.add_router("person", profile_router)
 def get_user(request, id: str):
     """Just a demo, do not build against this"""
     try:
-        return core_services.get_identity_by_id(id=id)
+        return core_services.get_profile_by_id(id=id)
     except Profile.DoesNotExist:
         return 404, {
             "message": "Unable to find user",

--- a/core/api/scim.py
+++ b/core/api/scim.py
@@ -27,7 +27,7 @@ router = Router()
 def get_user(request, id: str):
     """Returns the Identity record (internally: Profile) with the given ID"""
     try:
-        return core_services.get_identity_by_id(id=id, include_inactive=True)
+        return core_services.get_profile_by_id(id=id, include_inactive=True)
     except Profile.DoesNotExist:
         return 404, {
             "status": "404",
@@ -92,7 +92,7 @@ def update_user(
         primary_email = scim_user.get_primary_email()
         contact_email = scim_user.get_contact_email()
 
-        profile = core_services.get_identity_by_id(id=id, include_inactive=True)
+        profile = core_services.get_profile_by_id(id=id, include_inactive=True)
 
         core_services.update_identity(
             profile=profile,
@@ -118,7 +118,7 @@ def delete_user(
 ) -> int | tuple[int, dict]:
     """Deleted the Identity record with the given ID"""
     try:
-        profile = core_services.get_identity_by_id(id=id, include_inactive=True)
+        profile = core_services.get_profile_by_id(id=id, include_inactive=True)
         core_services.delete_identity(
             profile=profile,
         )

--- a/core/api/sso_profile.py
+++ b/core/api/sso_profile.py
@@ -19,7 +19,7 @@ router = Router()
 def get_user(request, id: str):
     """Optimised, low-flexibility endpoint to return a minimal Identity record (internally: Profile)"""
     try:
-        return core_services.get_identity_by_id(id=id)
+        return core_services.get_profile_by_id(id=id)
     except Profile.DoesNotExist:
         return 404, {
             "message": "Unable to find user",

--- a/core/management/commands/create_identity_fixture.py
+++ b/core/management/commands/create_identity_fixture.py
@@ -77,7 +77,9 @@ class Command(BaseCommand):
             user_services.update_by_id(
                 sso_email_id=p.sso_email_id, is_staff=staff, is_superuser=superuser
             )
-            usr = User.objects.get(sso_email_id=p.sso_email_id)
+            usr = user_services.get_by_id(
+                sso_email_id=p.sso_email_id, include_inactive=True
+            )
             usr.set_password(sso_email_id)
             usr.save()
             self.stdout.write(msg=f"Password set to '{sso_email_id}'")

--- a/core/services.py
+++ b/core/services.py
@@ -100,16 +100,15 @@ def delete_identity(profile: Profile) -> None:
     """
     Function for deleting an existing user and their profile information.
     """
+    profile_id = profile.sso_email_id
 
     profile_services.delete_sso_profile(profile=profile)
     profile_services.delete_combined_profile(profile=profile)
 
     # delete user if no profile exists for user
-    all_profiles = profile_services.get_all_profiles(sso_email_id=profile.sso_email_id)
+    all_profiles = profile_services.get_all_profiles(sso_email_id=profile_id)
     if not all_profiles:
-        user = user_services.get_by_id(
-            sso_email_id=profile.sso_email_id, include_inactive=True
-        )
+        user = user_services.get_by_id(sso_email_id=profile_id, include_inactive=True)
         user_services.delete_from_database(user=user)
 
 

--- a/core/services.py
+++ b/core/services.py
@@ -9,7 +9,6 @@ from core.utils.s3_helper import (
 )
 from profiles import services as profile_services
 from profiles.models.combined import Profile
-from profiles.services import get_all_profiles
 from profiles.types import UNSET, Unset  # noqa
 from user import services as user_services
 from user.models import User
@@ -25,9 +24,9 @@ SSO_USER_STATUS = "dit:StaffSSO:User:status"
 logger = logging.getLogger(__name__)
 
 
-def get_identity_by_id(id: str, include_inactive: bool = False) -> Profile:
+def get_profile_by_id(id: str, include_inactive: bool = False) -> Profile:
     """
-    Retrieve an identity by its User ID.
+    Retrieve an profile by its User ID.
     """
     return profile_services.get_by_id(
         sso_email_id=id, include_inactive=include_inactive
@@ -76,12 +75,16 @@ def update_identity(
     Function for updating an existing user (archive / unarchive) and their profile information.
     """
 
-    user = User.objects.get(sso_email_id=profile.sso_email_id)
+    user = user_services.get_by_id(
+        sso_email_id=profile.sso_email_id, include_inactive=True
+    )
     if user.is_active != is_active:
         if user.is_active == False:
             user_services.unarchive(user)
+            profile_services.unarchive(profile=profile)
         else:
             user_services.archive(user)
+            profile_services.archive(profile=profile)
 
     profile_services.update_from_sso(
         profile=profile,
@@ -98,12 +101,15 @@ def delete_identity(profile: Profile) -> None:
     Function for deleting an existing user and their profile information.
     """
 
-    profile_services.delete_from_sso(profile=profile)
+    profile_services.delete_sso_profile(profile=profile)
+    profile_services.delete_combined_profile(profile=profile)
 
     # delete user if no profile exists for user
-    all_profiles = get_all_profiles(sso_email_id=profile.sso_email_id)
+    all_profiles = profile_services.get_all_profiles(sso_email_id=profile.sso_email_id)
     if not all_profiles:
-        user = User.objects.get(sso_email_id=profile.sso_email_id)
+        user = user_services.get_by_id(
+            sso_email_id=profile.sso_email_id, include_inactive=True
+        )
         user_services.delete_from_database(user=user)
 
 
@@ -132,11 +138,22 @@ def bulk_delete_identity_users_from_sso(sso_users: list[dict[str, Any]]) -> None
 
     id_users_to_delete = id_users.exclude(sso_email_id__in=sso_user_ids)
     for user in id_users_to_delete:
-        profile = get_identity_by_id(user.sso_email_id, include_inactive=True)
-        # log Staff SSO objects that are no longer in the S3 file.
-        logger.info(f"ingest_staff_sso_s3: Deactivating account {user.sso_email_id}")
+        try:
+            profile = get_profile_by_id(user.sso_email_id, include_inactive=True)
+            # log Staff SSO objects that are no longer in the S3 file.
+            logger.info(
+                f"ingest_staff_sso_s3: Deactivating account {user.sso_email_id}"
+            )
 
-        delete_identity(profile=profile)
+            delete_identity(profile=profile)
+        except Profile.DoesNotExist:
+            logger.info(
+                f"Profile does not exist for the user, deleting the user record {user.sso_email_id}"
+            )
+            user_services.delete_from_database(
+                user=user,
+                reason="Bulk delete - Profile does not exist",
+            )
 
 
 def bulk_create_and_update_identity_users_from_sso(
@@ -161,26 +178,40 @@ def bulk_create_and_update_identity_users_from_sso(
                 contact_email=contact_email,
             )
         else:
-            profile = get_identity_by_id(
-                id=sso_user[SSO_USER_EMAIL_ID], include_inactive=True
-            )
             primary_email, contact_email, all_emails = extract_emails_from_sso_user(
                 sso_user
             )
-            update_identity(
-                profile=profile,
-                first_name=sso_user[SSO_FIRST_NAME],
-                last_name=sso_user[SSO_LAST_NAME],
-                all_emails=all_emails,
-                is_active=sso_user[SSO_USER_STATUS] == "active",
-                primary_email=primary_email,
-                contact_email=contact_email,
+            try:
+                profile = get_profile_by_id(
+                    id=sso_user[SSO_USER_EMAIL_ID], include_inactive=True
+                )
+                update_identity(
+                    profile=profile,
+                    first_name=sso_user[SSO_FIRST_NAME],
+                    last_name=sso_user[SSO_LAST_NAME],
+                    all_emails=all_emails,
+                    is_active=sso_user[SSO_USER_STATUS] == "active",
+                    primary_email=primary_email,
+                    contact_email=contact_email,
+                )
+            except Profile.DoesNotExist:
+                profile = profile_services.create_from_sso(
+                    sso_email_id=sso_user[SSO_USER_EMAIL_ID],
+                    first_name=sso_user[SSO_FIRST_NAME],
+                    last_name=sso_user[SSO_LAST_NAME],
+                    all_emails=all_emails,
+                    primary_email=primary_email,
+                    contact_email=contact_email,
+                )
+
+        # if inactive sso user is currently active in ID, they should be archived
+        if sso_user[SSO_USER_STATUS] == "inactive":
+            user = user_services.get_by_id(
+                sso_email_id=sso_user[SSO_USER_EMAIL_ID], include_inactive=True
             )
-            # if inactive sso user is currently active in ID, they should be archived
-            if sso_user[SSO_USER_STATUS] == "inactive":
-                user = User.objects.get(sso_email_id=sso_user[SSO_USER_EMAIL_ID])
-                if user.is_active:
-                    user_services.archive(user)
+            if user.is_active:
+                user_services.archive(user)
+                profile_services.archive(profile=profile)
 
 
 def extract_emails_from_sso_user(sso_user) -> tuple[str, str, list[str]]:

--- a/e2e_tests/test_scim.py
+++ b/e2e_tests/test_scim.py
@@ -21,7 +21,7 @@ def test_create(scim_user_factory):
     url = reverse("scim:create_user")
 
     with pytest.raises(Profile.DoesNotExist):
-        services.get_identity_by_id(scim_user_dict["id"], include_inactive=True)
+        services.get_profile_by_id(scim_user_dict["id"], include_inactive=True)
 
     response = client.post(
         url,
@@ -30,7 +30,7 @@ def test_create(scim_user_factory):
     )
 
     assert response.status_code == 201
-    profile = services.get_identity_by_id(scim_user_dict["id"], include_inactive=True)
+    profile = services.get_profile_by_id(scim_user_dict["id"], include_inactive=True)
     assert profile.first_name == scim_user_dict["name"]["givenName"]
     assert profile.last_name == scim_user_dict["name"]["familyName"]
     assert len(profile.emails) == len(scim_user_dict["emails"])

--- a/profiles/exceptions.py
+++ b/profiles/exceptions.py
@@ -11,3 +11,8 @@ class ProfileIsNotArchived(Exception):
 class ProfileExists(Exception):
     def __init__(self, message):
         self.message = message
+
+
+class NonCombinedProfileExists(Exception):
+    def __init__(self, message):
+        self.message = message

--- a/profiles/services/__init__.py
+++ b/profiles/services/__init__.py
@@ -210,7 +210,7 @@ def delete_combined_profile(profile: Profile) -> None:
     if len(all_profiles) == 1 and "combined" in all_profiles:
         combined.delete_from_database(profile=profile)
     else:
-        raise NonCombinedProfileExists(f"All existing profiles: {all_profiles.keys}")
+        raise NonCombinedProfileExists(f"All existing profiles: {all_profiles.keys()}")
 
 
 def delete_sso_profile(profile: Profile) -> None:

--- a/profiles/services/__init__.py
+++ b/profiles/services/__init__.py
@@ -1,12 +1,20 @@
 # This is the entrypoint service that coordinates between the sub-services
 # If in doubt about what to use, you should probably be using this
+import logging
 from typing import Optional
 
 from django.db import models
 
+from profiles.exceptions import NonCombinedProfileExists
 from profiles.models.combined import Profile
+from profiles.models.staff_sso import StaffSSOProfile
 from profiles.services import combined, staff_sso
 from profiles.types import Unset
+from user import services as user_services
+from user.models import User
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_by_id(sso_email_id: str, include_inactive: bool = False) -> Profile:
@@ -25,7 +33,11 @@ def generate_combined_profile_data(sso_email_id: str):
     create method
     """
     sso_profile = staff_sso.get_by_id(sso_email_id=sso_email_id, include_inactive=True)
-    user = sso_profile.user
+
+    try:
+        user = sso_profile.user
+    except sso_profile.DoesNotExist:
+        user = user_services.get_by_id(sso_email_id=sso_email_id, include_inactive=True)
 
     primary_email = sso_profile.primary_email
     if primary_email is None:
@@ -114,18 +126,24 @@ def update_from_sso(
     )
 
 
-def delete_from_sso(profile: Profile) -> None:
-    sso_profile = staff_sso.get_by_id(profile.sso_email_id, include_inactive=True)
-    staff_sso.delete_from_database(sso_profile=sso_profile)
-
+def delete_combined_profile(profile: Profile) -> None:
     all_profiles = get_all_profiles(sso_email_id=profile.sso_email_id)
 
-    # check if combined profile is the only profile left for user
-    if [key for key in all_profiles] == ["combined"]:
-        combined_profile = combined.get_by_id(
-            sso_email_id=profile.sso_email_id, include_inactive=True
+    # check and delete if combined profile is the only profile left for user
+    if len(all_profiles) == 1 and "combined" in all_profiles:
+        combined.delete_from_database(profile=profile)
+    else:
+        raise NonCombinedProfileExists(f"All existing profiles: {all_profiles.keys}")
+
+
+def delete_sso_profile(profile: Profile) -> None:
+    try:
+        sso_profile = staff_sso.get_by_id(profile.sso_email_id, include_inactive=True)
+        staff_sso.delete_from_database(sso_profile=sso_profile)
+    except StaffSSOProfile.DoesNotExist:
+        logger.debug(
+            f"Failed to delete SSO profile for {profile.sso_email_id}. SSO profile is already deleted."
         )
-        combined.delete_from_database(profile=combined_profile)
 
 
 def get_all_profiles(sso_email_id: str) -> dict[str, models.Model]:
@@ -146,3 +164,27 @@ def get_all_profiles(sso_email_id: str) -> dict[str, models.Model]:
         pass
     # TODO - more profiles to be added here as we implement more
     return all_profile
+
+
+def archive(
+    profile: Profile,
+    reason: Optional[str] = None,
+    requesting_user: Optional[User] = None,
+) -> None:
+    combined.archive(
+        profile=profile,
+        reason=reason,
+        requesting_user=requesting_user,
+    )
+
+
+def unarchive(
+    profile: Profile,
+    reason: Optional[str] = None,
+    requesting_user: Optional[User] = None,
+) -> None:
+    combined.unarchive(
+        profile=profile,
+        reason=reason,
+        requesting_user=requesting_user,
+    )

--- a/profiles/services/combined.py
+++ b/profiles/services/combined.py
@@ -125,12 +125,6 @@ def update(
         change_message=reason,
         action_flag=CHANGE,
     )
-    if is_active is not None:
-        if is_active:
-            if not profile.is_active:
-                unarchive(profile)
-        else:
-            archive(profile)
 
 
 def archive(

--- a/profiles/services/staff_sso.py
+++ b/profiles/services/staff_sso.py
@@ -51,7 +51,7 @@ def create(
     if contact_email is not None and contact_email not in all_emails:
         raise ValueError("contact_email not in all_emails")
 
-    user = user_services.get_by_id(sso_email_id=sso_email_id)
+    user = user_services.get_by_id(sso_email_id=sso_email_id, include_inactive=True)
     staff_sso_profile = StaffSSOProfile.objects.create(
         user=user,
         first_name=first_name,

--- a/user/services.py
+++ b/user/services.py
@@ -21,13 +21,13 @@ else:
 #### ID is required - no getting around it ####
 
 
-def get_by_id(sso_email_id: str) -> User:
+def get_by_id(sso_email_id: str, include_inactive: bool = False) -> User:
     """
-    Retrieve a user by their ID, only if the user is not soft-deleted.
+    Retrieve a user by their ID.
     """
     try:
         user = User.objects.get(sso_email_id=sso_email_id)
-        if user.is_active:
+        if user.is_active or include_inactive:
             return user
         else:
             raise UserIsArchived("User has been previously deleted")


### PR DESCRIPTION
This PR includes handling partial records correctly in batch processes and refactoring that is relevant to `create_identity`, `update_identity` and `delete_identity` functions, these functions are used by the bulk update/create and delete functions.
- Initially the PR only covered the bug fixes in bulk update/create and delete functions, however while having a squad discussion on those, we noticed some areas for improvement.

New tests are added and the existing tests are up to date.