### PR TITLE
IDPF-384 Update Celery Tasks to override default behaviour

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -4,7 +4,7 @@ from .base import *  # noqa
 DEBUG = False
 
 AWS_S3_URL_PROTOCOL = "https:"
-AWS_S3_CUSTOM_DOMAIN = env("AWS_S3_CUSTOM_DOMAIN")  # noqa F405
+AWS_S3_CUSTOM_DOMAIN = env("AWS_S3_CUSTOM_DOMAIN", default=None)  # noqa F405
 AWS_QUERYSTRING_AUTH = False
 
 SESSION_COOKIE_AGE: int = 60 * 60

--- a/core/utils.py
+++ b/core/utils.py
@@ -12,7 +12,7 @@ from core.services import (
     update_identity,
 )
 from data_flow_s3_import import ingest
-from identity.data_flow_s3_import.types import PrimaryKey
+from data_flow_s3_import.types import PrimaryKey
 from profiles.models.combined import Profile
 from profiles.models.generic import Country, UkStaffLocation
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import boto3
@@ -11,6 +12,7 @@ from core.services import (
     update_identity,
 )
 from data_flow_s3_import import ingest
+from identity.data_flow_s3_import.types import PrimaryKey
 from profiles.models.combined import Profile
 from profiles.models.generic import Country, UkStaffLocation
 
@@ -133,6 +135,13 @@ class CountriesS3Ingest(DataFlowS3IngestToModel):
         "overseas_region": "overseas_region",
     }
 
+    def process_row(self, line: str) -> PrimaryKey:
+        """
+        Takes a row of the file, retrieves a dict of the instance it refers to and hands that off for processing
+        """
+        obj: dict = json.loads(s=line)  # Countries does not wrap content in 'object'
+        return self._process_object_workflow(obj=obj)
+
 
 class UkStaffLocationsS3Ingest(DataFlowS3IngestToModel):
     export_bucket: str = settings.DATA_FLOW_UPLOADS_BUCKET
@@ -146,3 +155,12 @@ class UkStaffLocationsS3Ingest(DataFlowS3IngestToModel):
         "organisation": "organisation",
         "building_name": "building_name",
     }
+
+    def process_row(self, line: str) -> PrimaryKey:
+        """
+        Takes a row of the file, retrieves a dict of the instance it refers to and hands that off for processing
+        """
+        obj: dict = json.loads(
+            s=line
+        )  # UkStaffLocation does not wrap content in 'object'
+        return self._process_object_workflow(obj=obj)


### PR DESCRIPTION
The default behaviour for `process_row` is incorrect for Countries and UKStaffLocations, as these are not wrapped in a 'object' instead returned directly.
<!--
Please ensure that you have:
- Referenced the JIRA ticket in the PR title
- Made sure the PR title is clear and concise as a commit message on `main`
- Put all relevant detail in this description area

And also that:
- Tests are up to date
- Documentation is up to date
-->
