### PR TITLE
IDPF-378: Resize images on demand

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -11,5 +11,10 @@ urlpatterns = [
         view=views.profile_photo_handler,
         name="photo",
     ),
+    path(
+        route="profiles/<str:slug>/photo/<int:x>/<int:y>",
+        view=views.get_profile_photo,
+        name="photo",
+    ),
     path("sentry-debug/", views.trigger_error, name="sentry-debug"),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,6 @@
-from io import BytesIO
 import json
 import mimetypes
+from io import BytesIO
 
 from django import forms
 from django.conf import settings
@@ -24,9 +24,9 @@ from django.views.decorators.csrf import csrf_exempt
 from core import services
 from core.api import do_hawk_auth
 from core.schemas.peoplefinder.profile import ProfileResponse
+from profiles import utils
 from profiles.models.peoplefinder import PeopleFinderProfile
 from profiles.services import image as img_service
-from profiles import utils
 
 
 class PhotoForm(forms.Form):
@@ -72,7 +72,7 @@ def profile_photo_handler(request: HttpRequest, slug: str):
     return HttpResponseNotAllowed(["GET", "POST", "DELETE"])
 
 
-def get_profile_photo(request, slug: str, x:int|None = None, y:int|None = None):
+def get_profile_photo(request, slug: str, x: int | None = None, y: int | None = None):
     """
     Proxy endpoint to retrieve profile photo. Ensures requesting user is authenticated.
     """
@@ -98,7 +98,9 @@ def get_profile_photo(request, slug: str, x:int|None = None, y:int|None = None):
     else:
         size = (x, y)
         prefix = f"{x}x{y}"
-        image = utils.get_or_create_sized_image(original_filename=profile.photo.name, size=size, prefix=prefix)
+        image = utils.get_or_create_sized_image(
+            original_filename=profile.photo.name, size=size, prefix=prefix
+        )
 
     return FileResponse(image, True)
 

--- a/core/views.py
+++ b/core/views.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 import json
 import mimetypes
 
@@ -5,7 +6,9 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
+from django.core.files.base import File
 from django.http import (
+    FileResponse,
     Http404,
     HttpRequest,
     HttpResponse,
@@ -13,6 +16,7 @@ from django.http import (
     HttpResponseForbidden,
     HttpResponseNotAllowed,
     HttpResponseNotFound,
+    StreamingHttpResponse,
 )
 from django.shortcuts import HttpResponse, redirect, render
 from django.views.decorators.csrf import csrf_exempt
@@ -21,6 +25,8 @@ from core import services
 from core.api import do_hawk_auth
 from core.schemas.peoplefinder.profile import ProfileResponse
 from profiles.models.peoplefinder import PeopleFinderProfile
+from profiles.services import image as img_service
+from profiles import utils
 
 
 class PhotoForm(forms.Form):
@@ -66,12 +72,16 @@ def profile_photo_handler(request: HttpRequest, slug: str):
     return HttpResponseNotAllowed(["GET", "POST", "DELETE"])
 
 
-def get_profile_photo(request, slug: str):
+def get_profile_photo(request, slug: str, x:int|None = None, y:int|None = None):
     """
     Proxy endpoint to retrieve profile photo. Ensures requesting user is authenticated.
     """
     if not request.user.is_authenticated:
         return redirect(f"{settings.LOGIN_URL}")
+
+    if request.method != "GET":
+        # generally means someone has tried to access the resize param URL
+        return HttpResponseNotAllowed(["GET"])
 
     try:
         profile = services.get_peoplefinder_profile_by_slug(slug=slug)
@@ -81,11 +91,16 @@ def get_profile_photo(request, slug: str):
     if not bool(profile.photo):
         return HttpResponse("")
 
-    image = profile.photo.open()
-    response = HttpResponse(content=image)
-    response["Content-Type"] = str(mimetypes.guess_type(image.url)[0])
-    response["Content-Length"] = image.size
-    return response
+    if x is None:
+        image = img_service.get_main_profile_photo(slug)
+    elif y is None:
+        raise ValueError("If X is set Y must also be set for a custom image dimension")
+    else:
+        size = (x, y)
+        prefix = f"{x}x{y}"
+        image = utils.get_or_create_sized_image(original_filename=profile.photo.name, size=size, prefix=prefix)
+
+    return FileResponse(image, True)
 
 
 @csrf_exempt

--- a/e2e_tests/test_peoplefinder.py
+++ b/e2e_tests/test_peoplefinder.py
@@ -1,11 +1,14 @@
 import datetime as dt
+from io import BytesIO
 import json
 import os
 import uuid
 
 import pytest
+from django.http import StreamingHttpResponse
 from django.test.client import Client
 from django.urls import reverse
+from regex import B
 
 from core.schemas.peoplefinder.profile import CreateProfileRequest, UpdateProfileRequest
 from profiles.models import LearningInterest, Workday
@@ -388,6 +391,12 @@ def test_upload_delete_photo(peoplefinder_profile):
     url = reverse("core:photo", args=(str(peoplefinder_profile.slug),))
     filepath = "docker/.localstack/fixtures/photo.jpg"
     client = Client()
+    client.force_login(peoplefinder_profile.user)
+    local_file_size = os.path.getsize(filepath)
+
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.content) == 0
 
     with open(filepath, "rb") as file:
         response = client.post(
@@ -396,12 +405,34 @@ def test_upload_delete_photo(peoplefinder_profile):
         )
         assert response.status_code == 200
         peoplefinder_profile.refresh_from_db()
-        assert peoplefinder_profile.photo.size == os.path.getsize(filepath)
+        assert peoplefinder_profile.photo.size == local_file_size
 
+    response = client.get(url)
+    assert response.status_code == 200
+    if isinstance(response, StreamingHttpResponse):
+        content = response.getvalue().decode('utf-8')
+    else:
+        content = response.content
+    assert len(content) == local_file_size
+
+    url = reverse("core:photo", args=(str(peoplefinder_profile.slug), 80, 80))
+    response = client.get(url)
+    assert response.status_code == 200
+    if isinstance(response, StreamingHttpResponse):
+        content = response.getvalue()
+    else:
+        content = response.content
+    assert 0 < len(content) < local_file_size
+
+    url = reverse("core:photo", args=(str(peoplefinder_profile.slug),))
     response = client.delete(url)
     assert response.status_code == 200
     peoplefinder_profile.refresh_from_db()
     assert bool(peoplefinder_profile.photo) is False
+
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(content) == 0
 
     filepath = "docker/.localstack/fixtures/staff_sso.jsonl"
     with open(filepath, "rb") as file:

--- a/e2e_tests/test_views.py
+++ b/e2e_tests/test_views.py
@@ -20,13 +20,3 @@ def test_photo_only_authorised_access(peoplefinder_profile):
     client.force_login(peoplefinder_profile.user)
     response = client.get(url)
     assert response.status_code == 200
-    assert len(response.content) == 0  # no photo exists
-
-    local_file = open("docker/.localstack/fixtures/photo.jpg", "rb")
-    djangofile = File(local_file)
-    peoplefinder_profile.photo.save("new", djangofile)
-    local_file.close()
-
-    response = client.get(url)
-    assert response.status_code == 200
-    assert len(response.content) == djangofile.size

--- a/profiles/services/image.py
+++ b/profiles/services/image.py
@@ -1,7 +1,5 @@
-from django.db.models.fields.files import ImageFieldFile
-
 from profiles.services import peoplefinder_profile_services
-from profiles.types import ImageDimensions, ImageStandardSizes
+from profiles.types import ImageStandardSizes
 from profiles.utils import (
     get_dimensions_and_prefix_from_standard_size,
     get_or_create_sized_image,
@@ -12,7 +10,11 @@ def get_standard_profile_photo(slug: str, standard_size: ImageStandardSizes):
     profile: peoplefinder_profile_services.PeopleFinderProfile = (
         peoplefinder_profile_services.get_by_slug(slug=slug, include_inactive=True)
     )
+    if not bool(profile.photo):
+        return None
+
     size, prefix = get_dimensions_and_prefix_from_standard_size(standard_size)
+
     return get_or_create_sized_image(profile.photo.name, size, prefix)
 
 
@@ -25,4 +27,6 @@ def get_small_profile_photo(slug: str):
 
 
 def get_thumbnail_profile_photo(slug: str):
-    return get_standard_profile_photo(slug=slug, standard_size=ImageStandardSizes.THUMBNAIL)
+    return get_standard_profile_photo(
+        slug=slug, standard_size=ImageStandardSizes.THUMBNAIL
+    )

--- a/profiles/services/image.py
+++ b/profiles/services/image.py
@@ -17,12 +17,12 @@ def get_standard_profile_photo(slug: str, standard_size: ImageStandardSizes):
 
 
 def get_main_profile_photo(slug: str):
-    return get_standard_profile_photo(slug, ImageStandardSizes.MAIN)
+    return get_standard_profile_photo(slug=slug, standard_size=ImageStandardSizes.MAIN)
 
 
 def get_small_profile_photo(slug: str):
-    return get_standard_profile_photo(slug, ImageStandardSizes.SMALL)
+    return get_standard_profile_photo(slug=slug, standard_size=ImageStandardSizes.SMALL)
 
 
 def get_thumbnail_profile_photo(slug: str):
-    return get_standard_profile_photo(slug, ImageStandardSizes.THUMBNAIL)
+    return get_standard_profile_photo(slug=slug, standard_size=ImageStandardSizes.THUMBNAIL)

--- a/profiles/tests/peoplefinder/test_services_image.py
+++ b/profiles/tests/peoplefinder/test_services_image.py
@@ -1,28 +1,73 @@
+from re import T
+
 import pytest
 
 from profiles import types
 from profiles.services import image
 
+
 pytestmark = pytest.mark.django_db
 
 
-def test_get_standard_profile_photo():
-    assert False
+def test_get_standard_profile_photo(mocker):
+    profile = mocker.Mock()
+    profile.photo = False
+    mock_svc = mocker.patch("profiles.services.image.peoplefinder_profile_services")
+    mock_svc.get_by_slug.return_value = profile
+    mock_get_dims = mocker.patch(
+        "profiles.services.image.get_dimensions_and_prefix_from_standard_size",
+        return_value=("--size--", "--prefix--"),
+    )
+    mock_get_or_create = mocker.patch(
+        "profiles.services.image.get_or_create_sized_image"
+    )
+
+    assert (
+        image.get_standard_profile_photo("SLUG", types.ImageStandardSizes.MAIN) == None
+    )
+    mock_get_dims.assert_not_called()
+    mock_get_or_create.assert_not_called()
+
+    profile.photo = mocker.Mock()
+    assert (
+        image.get_standard_profile_photo("SLUG", types.ImageStandardSizes.MAIN)
+        == mock_get_or_create.return_value
+    )
+    mock_get_dims.assert_called_once_with(types.ImageStandardSizes.MAIN)
+    mock_get_or_create.assert_called_once_with(
+        profile.photo.name, "--size--", "--prefix--"
+    )
+
+    mock_get_dims.reset_mock()
+    image.get_standard_profile_photo("SLUG", types.ImageStandardSizes.THUMBNAIL)
+    mock_get_dims.assert_called_once_with(types.ImageStandardSizes.THUMBNAIL)
 
 
 def test_get_main_profile_photo(mocker):
-    mock_std_profile = mocker.patch("profiles.services.image.get_standard_profile_photo")
+    mock_std_profile = mocker.patch(
+        "profiles.services.image.get_standard_profile_photo"
+    )
     image.get_main_profile_photo(slug="a-slug")
-    mock_std_profile.assert_called_once_with(slug="a-slug", standard_size=types.ImageStandardSizes.MAIN)
+    mock_std_profile.assert_called_once_with(
+        slug="a-slug", standard_size=types.ImageStandardSizes.MAIN
+    )
 
 
 def test_get_small_profile_photo(mocker):
-    mock_std_profile = mocker.patch("profiles.services.image.get_standard_profile_photo")
+    mock_std_profile = mocker.patch(
+        "profiles.services.image.get_standard_profile_photo"
+    )
     image.get_small_profile_photo(slug="a-slug")
-    mock_std_profile.assert_called_once_with(slug="a-slug", standard_size=types.ImageStandardSizes.SMALL)
+    mock_std_profile.assert_called_once_with(
+        slug="a-slug", standard_size=types.ImageStandardSizes.SMALL
+    )
 
 
 def test_get_thumbnail_profile_photo(mocker):
-    mock_std_profile = mocker.patch("profiles.services.image.get_standard_profile_photo")
+    mock_std_profile = mocker.patch(
+        "profiles.services.image.get_standard_profile_photo"
+    )
     image.get_thumbnail_profile_photo(slug="a-slug")
-    mock_std_profile.assert_called_once_with(slug="a-slug", standard_size=types.ImageStandardSizes.THUMBNAIL)
+    mock_std_profile.assert_called_once_with(
+        slug="a-slug", standard_size=types.ImageStandardSizes.THUMBNAIL
+    )

--- a/profiles/tests/peoplefinder/test_services_image.py
+++ b/profiles/tests/peoplefinder/test_services_image.py
@@ -1,5 +1,6 @@
 import pytest
 
+from profiles import types
 from profiles.services import image
 
 pytestmark = pytest.mark.django_db
@@ -10,12 +11,18 @@ def test_get_standard_profile_photo():
 
 
 def test_get_main_profile_photo():
-    assert False
+    mock_std_profile = mocker.patch("profiles.services.image.get_standard_profile_photo")
+    image.get_thumbnail_profile_photo(slug="a-slug")
+    mock_std_profile.assert_called_once_with(slug="a-slug", standard_size=types.ImageStandardSizes.MAIN)
 
 
 def test_get_small_profile_photo():
-    assert False
+    mock_std_profile = mocker.patch("profiles.services.image.get_standard_profile_photo")
+    image.get_thumbnail_profile_photo(slug="a-slug")
+    mock_std_profile.assert_called_once_with(slug="a-slug", standard_size=types.ImageStandardSizes.SMALL)
 
 
-def test_get_thumbnail_profile_photo():
-    assert False
+def test_get_thumbnail_profile_photo(mocker):
+    mock_std_profile = mocker.patch("profiles.services.image.get_standard_profile_photo")
+    image.get_thumbnail_profile_photo(slug="a-slug")
+    mock_std_profile.assert_called_once_with(slug="a-slug", standard_size=types.ImageStandardSizes.THUMBNAIL)

--- a/profiles/tests/peoplefinder/test_services_image.py
+++ b/profiles/tests/peoplefinder/test_services_image.py
@@ -1,0 +1,21 @@
+import pytest
+
+from profiles.services import image
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_standard_profile_photo():
+    assert False
+
+
+def test_get_main_profile_photo():
+    assert False
+
+
+def test_get_small_profile_photo():
+    assert False
+
+
+def test_get_thumbnail_profile_photo():
+    assert False

--- a/profiles/tests/peoplefinder/test_services_image.py
+++ b/profiles/tests/peoplefinder/test_services_image.py
@@ -10,15 +10,15 @@ def test_get_standard_profile_photo():
     assert False
 
 
-def test_get_main_profile_photo():
+def test_get_main_profile_photo(mocker):
     mock_std_profile = mocker.patch("profiles.services.image.get_standard_profile_photo")
-    image.get_thumbnail_profile_photo(slug="a-slug")
+    image.get_main_profile_photo(slug="a-slug")
     mock_std_profile.assert_called_once_with(slug="a-slug", standard_size=types.ImageStandardSizes.MAIN)
 
 
-def test_get_small_profile_photo():
+def test_get_small_profile_photo(mocker):
     mock_std_profile = mocker.patch("profiles.services.image.get_standard_profile_photo")
-    image.get_thumbnail_profile_photo(slug="a-slug")
+    image.get_small_profile_photo(slug="a-slug")
     mock_std_profile.assert_called_once_with(slug="a-slug", standard_size=types.ImageStandardSizes.SMALL)
 
 

--- a/profiles/tests/test_utils.py
+++ b/profiles/tests/test_utils.py
@@ -522,9 +522,10 @@ def test_get_or_create_sized_image(mocker):
     save_file.assert_not_called()
 
     open_file.side_effect = [
-        FileNotFoundError,
-        file,
-    ]  # raises on the first call but not the second
+        FileNotFoundError,  # uncreated sizxed file
+        file,  # oringinal file
+        sized_file,  # newly created sized file
+    ]
     open_file.reset_mock()
     assert (
         utils.get_or_create_sized_image(

--- a/profiles/tests/test_utils.py
+++ b/profiles/tests/test_utils.py
@@ -1,0 +1,38 @@
+import pytest
+
+from profiles import utils
+
+
+pytestmark = pytest.mark.django_db
+
+def test_get_file_from_storages():
+    assert False
+
+def test_write_file_to_storages():
+    assert False
+
+def test_get_storage_instance(mocker):
+    with pytest.raises(KeyError):
+        utils.get_storage_instance("nonexistent_backend")
+
+    mock_storages = mocker.patch("profiles.utils.storages")
+    utils.get_storage_instance("existing_backend")
+    mock_storages.create_storage.assert_called_once_with(mock_storages.backends["existing_backend"])
+
+    utils.get_storage_instance()
+    mock_storages.create_storage.assert_called_with(mock_storages.backends["default"])
+
+def test_get_dimensions_and_prefix_from_standard_size():
+    assert False
+
+def test_get_filename_for_image_size():
+    assert False
+
+def test_get_crop_values():
+    assert False
+
+def test_get_crop_dimensions():
+    assert False
+
+def test_resize_image():
+    assert False

--- a/profiles/tests/test_utils.py
+++ b/profiles/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from profiles import utils
+from profiles import types, utils
 
 
 pytestmark = pytest.mark.django_db
@@ -23,13 +23,91 @@ def test_get_storage_instance(mocker):
     mock_storages.create_storage.assert_called_with(mock_storages.backends["default"])
 
 def test_get_dimensions_and_prefix_from_standard_size():
-    assert False
+    assert len(types.ImageStandardSizes) == 4
+    for size in types.ImageStandardSizes:
+        dimensions, prefix = utils.get_dimensions_and_prefix_from_standard_size(size)
+        assert dimensions == size.dimensions
+        assert prefix == size.prefix
 
 def test_get_filename_for_image_size():
-    assert False
+    path = "my/deeply/nested/file.pdf"
+
+    assert utils.get_filename_for_image_size(path, "and/sized") == "my/deeply/nested/and/sized/file.pdf"
 
 def test_get_crop_values():
-    assert False
+    orig_dimensions = (1000, 1000)
+    amt = 100
+
+    #
+    # Crop into the WIDTH
+    #
+    dimension = types.Dimension.WIDTH
+    focus = types.FocusPointOption.CENTER
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (50, 0, 950, 1000)
+
+    focus = types.FocusPointOption.BOTTOM_MIDDLE
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (50, 0, 950, 1000)
+
+    focus = types.FocusPointOption.TOP_MIDDLE
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (50, 0, 950, 1000)
+
+    focus = types.FocusPointOption.TOP_LEFT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 900, 1000)
+
+    focus = types.FocusPointOption.MIDDLE_LEFT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 900, 1000)
+
+    focus = types.FocusPointOption.BOTTOM_LEFT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 900, 1000)
+
+    focus = types.FocusPointOption.TOP_RIGHT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (100, 0, 1000, 1000)
+
+    focus = types.FocusPointOption.MIDDLE_RIGHT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (100, 0, 1000, 1000)
+
+    focus = types.FocusPointOption.BOTTOM_RIGHT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (100, 0, 1000, 1000)
+
+    #
+    # Crop into the HEIGHT
+    #
+    dimension = types.Dimension.HEIGHT
+    focus = types.FocusPointOption.CENTER
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 50, 1000, 950)
+
+    focus = types.FocusPointOption.BOTTOM_MIDDLE
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 100, 1000, 1000)
+
+    focus = types.FocusPointOption.TOP_MIDDLE
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 1000, 900)
+
+    focus = types.FocusPointOption.TOP_LEFT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 1000, 900)
+
+    focus = types.FocusPointOption.MIDDLE_LEFT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 50, 1000, 950)
+
+    focus = types.FocusPointOption.BOTTOM_LEFT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 100, 1000, 1000)
+
+    focus = types.FocusPointOption.TOP_RIGHT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 1000, 900)
+
+    focus = types.FocusPointOption.MIDDLE_RIGHT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 50, 1000, 950)
+
+    focus = types.FocusPointOption.BOTTOM_RIGHT
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 100, 1000, 1000)
+
+    #
+    # Custom focus
+    #
+    focus = (500, 500)
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 50, 1000, 950)
+
+    focus = (450, 450)
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 950, 950)
 
 def test_get_crop_dimensions():
     assert False

--- a/profiles/tests/test_utils.py
+++ b/profiles/tests/test_utils.py
@@ -1,4 +1,3 @@
-from ctypes import util
 import pytest
 
 from profiles import types, utils

--- a/profiles/tests/test_utils.py
+++ b/profiles/tests/test_utils.py
@@ -1,3 +1,4 @@
+from ctypes import util
 import pytest
 
 from profiles import types, utils
@@ -103,14 +104,71 @@ def test_get_crop_values():
     #
     # Custom focus
     #
-    focus = (500, 500)
+    dimension = types.Dimension.HEIGHT
+    focus = (500, 500)  # type:ignore
     assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 50, 1000, 950)
 
-    focus = (450, 450)
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 950, 950)
+    focus = (450, 450)  # type:ignore
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 1000, 900)
+
+    focus = (750, 750)  # type:ignore
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 100, 1000, 1000)
+
+    dimension = types.Dimension.WIDTH
+    focus = (500, 500)  # type:ignore
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (50, 0, 950, 1000)
+
+    focus = (450, 450)  # type:ignore
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 900, 1000)
+
+    focus = (750, 750)  # type:ignore
+    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (100, 0, 1000, 1000)
+
+    focus = (1200, 1200)  # type: ignore
+    with pytest.raises(ValueError):
+        utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,)
+
+    dimension = types.Dimension.HEIGHT
+    with pytest.raises(ValueError):
+        utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,)
 
 def test_get_crop_dimensions():
-    assert False
+    orig_dimensions = (100, 300)
+    tgt_dimensions = (100, 300)
+    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (None, None)
+
+    tgt_dimensions = (50, 150)
+    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (None, None)
+
+    tgt_dimensions = (200, 600)
+    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (None, None)
+
+    tgt_dimensions = (100, 600)
+    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.WIDTH, 50)
+
+    tgt_dimensions = (300, 600)
+    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.HEIGHT, 100)
+
+    orig_dimensions = (300, 100)
+
+    tgt_dimensions = (100, 600)
+    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.WIDTH, 283)
+
+    tgt_dimensions = (300, 600)
+    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.WIDTH, 250)
+
+    tgt_dimensions = (600, 600)
+    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.WIDTH, 200)
+
+    tgt_dimensions = (600, 300)
+    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.WIDTH, 100)
+
+    tgt_dimensions = (1200, 300)
+    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.HEIGHT, 25)
+
 
 def test_resize_image():
+    assert False
+
+def test_get_or_create_sized_image():
     assert False

--- a/profiles/tests/test_utils.py
+++ b/profiles/tests/test_utils.py
@@ -1,3 +1,6 @@
+from re import A
+from unittest.mock import call
+
 import pytest
 
 from profiles import types, utils
@@ -5,11 +8,33 @@ from profiles import types, utils
 
 pytestmark = pytest.mark.django_db
 
-def test_get_file_from_storages():
-    assert False
 
-def test_write_file_to_storages():
-    assert False
+def test_open_file_from_storages(mocker):
+    mock_s = mocker.Mock()
+    mock_s.open.return_value = "a-file"
+    mock_get_storages = mocker.patch(
+        "profiles.utils.get_storage_instance", return_value=mock_s
+    )
+
+    file = utils.open_file_from_storages("file_name")
+    assert file == "a-file"
+    mock_get_storages.assert_called_once()
+    mock_s.open.assert_called_once_with("file_name", mode="rb")
+
+
+def test_save_file_to_storages(mocker):
+    mock_s = mocker.Mock()
+    mock_s.save.return_value = "a-file-name"
+    mock_get_storages = mocker.patch(
+        "profiles.utils.get_storage_instance", return_value=mock_s
+    )
+    file = mocker.Mock()
+
+    filename = utils.save_file_to_storages("file_name", content=file)
+    assert filename == "a-file-name"
+    mock_get_storages.assert_called_once()
+    mock_s.save.assert_called
+
 
 def test_get_storage_instance(mocker):
     with pytest.raises(KeyError):
@@ -17,10 +42,13 @@ def test_get_storage_instance(mocker):
 
     mock_storages = mocker.patch("profiles.utils.storages")
     utils.get_storage_instance("existing_backend")
-    mock_storages.create_storage.assert_called_once_with(mock_storages.backends["existing_backend"])
+    mock_storages.create_storage.assert_called_once_with(
+        mock_storages.backends["existing_backend"]
+    )
 
     utils.get_storage_instance()
     mock_storages.create_storage.assert_called_with(mock_storages.backends["default"])
+
 
 def test_get_dimensions_and_prefix_from_standard_size():
     assert len(types.ImageStandardSizes) == 4
@@ -29,10 +57,15 @@ def test_get_dimensions_and_prefix_from_standard_size():
         assert dimensions == size.dimensions
         assert prefix == size.prefix
 
+
 def test_get_filename_for_image_size():
     path = "my/deeply/nested/file.pdf"
 
-    assert utils.get_filename_for_image_size(path, "and/sized") == "my/deeply/nested/and/sized/file.pdf"
+    assert (
+        utils.get_filename_for_image_size(path, "and/sized")
+        == "my/deeply/nested/and/sized/file.pdf"
+    )
+
 
 def test_get_crop_values():
     orig_dimensions = (1000, 1000)
@@ -43,131 +76,479 @@ def test_get_crop_values():
     #
     dimension = types.Dimension.WIDTH
     focus = types.FocusPointOption.CENTER
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (50, 0, 950, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (50, 0, 950, 1000)
 
     focus = types.FocusPointOption.BOTTOM_MIDDLE
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (50, 0, 950, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (50, 0, 950, 1000)
 
     focus = types.FocusPointOption.TOP_MIDDLE
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (50, 0, 950, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (50, 0, 950, 1000)
 
     focus = types.FocusPointOption.TOP_LEFT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 900, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 0, 900, 1000)
 
     focus = types.FocusPointOption.MIDDLE_LEFT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 900, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 0, 900, 1000)
 
     focus = types.FocusPointOption.BOTTOM_LEFT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 900, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 0, 900, 1000)
 
     focus = types.FocusPointOption.TOP_RIGHT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (100, 0, 1000, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (100, 0, 1000, 1000)
 
     focus = types.FocusPointOption.MIDDLE_RIGHT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (100, 0, 1000, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (100, 0, 1000, 1000)
 
     focus = types.FocusPointOption.BOTTOM_RIGHT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (100, 0, 1000, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (100, 0, 1000, 1000)
 
     #
     # Crop into the HEIGHT
     #
     dimension = types.Dimension.HEIGHT
     focus = types.FocusPointOption.CENTER
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 50, 1000, 950)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 50, 1000, 950)
 
     focus = types.FocusPointOption.BOTTOM_MIDDLE
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 100, 1000, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 100, 1000, 1000)
 
     focus = types.FocusPointOption.TOP_MIDDLE
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 1000, 900)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 0, 1000, 900)
 
     focus = types.FocusPointOption.TOP_LEFT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 1000, 900)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 0, 1000, 900)
 
     focus = types.FocusPointOption.MIDDLE_LEFT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 50, 1000, 950)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 50, 1000, 950)
 
     focus = types.FocusPointOption.BOTTOM_LEFT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 100, 1000, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 100, 1000, 1000)
 
     focus = types.FocusPointOption.TOP_RIGHT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 1000, 900)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 0, 1000, 900)
 
     focus = types.FocusPointOption.MIDDLE_RIGHT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 50, 1000, 950)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 50, 1000, 950)
 
     focus = types.FocusPointOption.BOTTOM_RIGHT
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 100, 1000, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 100, 1000, 1000)
 
     #
     # Custom focus
     #
     dimension = types.Dimension.HEIGHT
     focus = (500, 500)  # type:ignore
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 50, 1000, 950)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 50, 1000, 950)
 
     focus = (450, 450)  # type:ignore
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 1000, 900)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 0, 1000, 900)
 
     focus = (750, 750)  # type:ignore
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 100, 1000, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 100, 1000, 1000)
 
     dimension = types.Dimension.WIDTH
     focus = (500, 500)  # type:ignore
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (50, 0, 950, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (50, 0, 950, 1000)
 
     focus = (450, 450)  # type:ignore
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (0, 0, 900, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (0, 0, 900, 1000)
 
     focus = (750, 750)  # type:ignore
-    assert utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,) == (100, 0, 1000, 1000)
+    assert utils.get_crop_values(
+        original_dimensions=orig_dimensions,
+        dimension=dimension,
+        amount_to_remove=amt,
+        focus_point=focus,
+    ) == (100, 0, 1000, 1000)
 
     focus = (1200, 1200)  # type: ignore
     with pytest.raises(ValueError):
-        utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,)
+        utils.get_crop_values(
+            original_dimensions=orig_dimensions,
+            dimension=dimension,
+            amount_to_remove=amt,
+            focus_point=focus,
+        )
 
     dimension = types.Dimension.HEIGHT
     with pytest.raises(ValueError):
-        utils.get_crop_values(original_dimensions=orig_dimensions, dimension=dimension, amount_to_remove=amt, focus_point=focus,)
+        utils.get_crop_values(
+            original_dimensions=orig_dimensions,
+            dimension=dimension,
+            amount_to_remove=amt,
+            focus_point=focus,
+        )
+
 
 def test_get_crop_dimensions():
     orig_dimensions = (100, 300)
     tgt_dimensions = (100, 300)
-    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (None, None)
+    assert utils.get_crop_dimensions(
+        original_dimensions=orig_dimensions,
+        target_dimensions=tgt_dimensions,
+    ) == (None, None)
 
     tgt_dimensions = (50, 150)
-    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (None, None)
+    assert utils.get_crop_dimensions(
+        original_dimensions=orig_dimensions,
+        target_dimensions=tgt_dimensions,
+    ) == (None, None)
 
     tgt_dimensions = (200, 600)
-    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (None, None)
+    assert utils.get_crop_dimensions(
+        original_dimensions=orig_dimensions,
+        target_dimensions=tgt_dimensions,
+    ) == (None, None)
 
     tgt_dimensions = (100, 600)
-    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.WIDTH, 50)
+    assert utils.get_crop_dimensions(
+        original_dimensions=orig_dimensions,
+        target_dimensions=tgt_dimensions,
+    ) == (types.Dimension.WIDTH, 50)
 
     tgt_dimensions = (300, 600)
-    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.HEIGHT, 100)
+    assert utils.get_crop_dimensions(
+        original_dimensions=orig_dimensions,
+        target_dimensions=tgt_dimensions,
+    ) == (types.Dimension.HEIGHT, 100)
 
     orig_dimensions = (300, 100)
 
     tgt_dimensions = (100, 600)
-    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.WIDTH, 283)
+    assert utils.get_crop_dimensions(
+        original_dimensions=orig_dimensions,
+        target_dimensions=tgt_dimensions,
+    ) == (types.Dimension.WIDTH, 283)
 
     tgt_dimensions = (300, 600)
-    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.WIDTH, 250)
+    assert utils.get_crop_dimensions(
+        original_dimensions=orig_dimensions,
+        target_dimensions=tgt_dimensions,
+    ) == (types.Dimension.WIDTH, 250)
 
     tgt_dimensions = (600, 600)
-    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.WIDTH, 200)
+    assert utils.get_crop_dimensions(
+        original_dimensions=orig_dimensions,
+        target_dimensions=tgt_dimensions,
+    ) == (types.Dimension.WIDTH, 200)
 
     tgt_dimensions = (600, 300)
-    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.WIDTH, 100)
+    assert utils.get_crop_dimensions(
+        original_dimensions=orig_dimensions,
+        target_dimensions=tgt_dimensions,
+    ) == (types.Dimension.WIDTH, 100)
 
     tgt_dimensions = (1200, 300)
-    assert utils.get_crop_dimensions(original_dimensions=orig_dimensions, target_dimensions=tgt_dimensions,) == (types.Dimension.HEIGHT, 25)
+    assert utils.get_crop_dimensions(
+        original_dimensions=orig_dimensions,
+        target_dimensions=tgt_dimensions,
+    ) == (types.Dimension.HEIGHT, 25)
 
 
-def test_resize_image():
-    assert False
+def test_resize_image(mocker):
+    PILImage = mocker.patch("profiles.utils.Image")
+    PILImageOps = mocker.patch("profiles.utils.ImageOps")
+    file = mocker.Mock()
+    img = mocker.Mock()
+    img.mode = "HSB"
+    PILImage.open.return_value = img
+    PILImageOps.exif_transpose.return_value = img
+    img.convert.return_value = img
+    img.crop.return_value = img
 
-def test_get_or_create_sized_image():
-    assert False
+    approach = types.RatioApproach.CROP
+    img.size = (100, 100)
+    with pytest.raises(NotImplementedError):
+        utils.resize_image(
+            file=file,
+            target_dimensions=(1000, 1000),
+            focus_point=types.FocusPointOption.CENTER,
+            approach=approach,
+        )
+    PILImage.open.assert_called_once_with(file)
+
+    img.size = (100, 2000)
+    with pytest.raises(NotImplementedError):
+        utils.resize_image(
+            file=img,
+            target_dimensions=(1000, 1000),
+            focus_point=types.FocusPointOption.CENTER,
+            approach=approach,
+        )
+
+    img.size = (2000, 2000)
+    with pytest.raises(NotImplementedError):
+        utils.resize_image(
+            file=img,
+            target_dimensions=(1000, 1000),
+            focus_point=types.FocusPointOption.CENTER,
+            approach=types.RatioApproach.FILL,
+        )
+
+    with pytest.raises(NotImplementedError):
+        utils.resize_image(
+            file=img,
+            target_dimensions=(1000, 1000),
+            focus_point=types.FocusPointOption.CENTER,
+            approach=types.RatioApproach.SQUASH,
+        )
+
+    mock_crop_dimensions = mocker.patch(
+        "profiles.utils.get_crop_dimensions", return_value=("-dimension-", "-amount-")
+    )
+    mock_crop_values = mocker.patch(
+        "profiles.utils.get_crop_values", return_value="crop-vals"
+    )
+    output = utils.resize_image(
+        file=img,
+        target_dimensions=(1000, 1000),
+        focus_point=types.FocusPointOption.CENTER,
+        approach=approach,
+    )
+    PILImageOps.exif_transpose.assert_called_once_with(img)
+    img.convert.assert_called_once_with("RGB")
+    mock_crop_dimensions.assert_called_once_with(
+        original_dimensions=(2000, 2000), target_dimensions=(1000, 1000)
+    )
+    mock_crop_values.assert_called_once_with(
+        original_dimensions=(2000, 2000),
+        dimension="-dimension-",
+        amount_to_remove="-amount-",
+        focus_point=types.FocusPointOption.CENTER,
+    )
+    img.crop.assert_called_once_with("crop-vals")
+    img.resize.assert_called_once_with((1000, 1000), PILImage.Resampling.BICUBIC)
+    assert output == img.resize.return_value
+
+    img.mode = "L"
+    img.convert.reset_mock()
+    assert (
+        utils.resize_image(
+            file=img,
+            target_dimensions=(1000, 1000),
+            focus_point=types.FocusPointOption.CENTER,
+            approach=approach,
+        )
+        == img.resize.return_value
+    )
+    img.convert.assert_not_called()
+
+    img.mode = "RGB"
+    img.convert.reset_mock()
+    assert (
+        utils.resize_image(
+            file=img,
+            target_dimensions=(1000, 1000),
+            focus_point=types.FocusPointOption.CENTER,
+            approach=approach,
+        )
+        == img.resize.return_value
+    )
+    img.convert.assert_not_called()
+
+    mock_crop_values.reset_mock()
+    assert (
+        utils.resize_image(
+            file=img,
+            target_dimensions=(1000, 1000),
+            focus_point=(200, 200),
+            approach=approach,
+        )
+        == img.resize.return_value
+    )
+    mock_crop_values.assert_called_once_with(
+        original_dimensions=(2000, 2000),
+        dimension="-dimension-",
+        amount_to_remove="-amount-",
+        focus_point=(200, 200),
+    )
+
+    mock_crop_dimensions.return_value = (None, None)
+    img.crop.reset_mock()
+    assert (
+        utils.resize_image(
+            file=img,
+            target_dimensions=(1000, 1000),
+            focus_point=types.FocusPointOption.CENTER,
+            approach=approach,
+        )
+        == img.resize.return_value
+    )
+    img.crop.assert_not_called()
+
+
+def test_get_or_create_sized_image(mocker):
+    file = mocker.Mock()
+    sized_file = mocker.Mock()
+    img = mocker.Mock()
+    get_filename = mocker.patch(
+        "profiles.utils.get_filename_for_image_size", return_value="--filename--"
+    )
+    open_file = mocker.patch(
+        "profiles.utils.open_file_from_storages", return_value=file
+    )
+    resize_img = mocker.patch("profiles.utils.resize_image", return_value=img)
+    BytesIO = mocker.patch("profiles.utils.BytesIO", return_value=sized_file)
+    save_file = mocker.patch(
+        "profiles.utils.save_file_to_storages", return_value=sized_file
+    )
+
+    assert (
+        utils.get_or_create_sized_image(
+            "orig",
+            (350, 350),
+            "-prefix-",
+        )
+        == file
+    )
+    get_filename.assert_called_once_with("orig", "-prefix-")
+    open_file.assert_called_once_with("--filename--")
+    resize_img.assert_not_called()
+    save_file.assert_not_called()
+
+    open_file.side_effect = [
+        FileNotFoundError,
+        file,
+    ]  # raises on the first call but not the second
+    open_file.reset_mock()
+    assert (
+        utils.get_or_create_sized_image(
+            "orig",
+            (350, 350),
+            "-prefix-",
+        )
+        == sized_file
+    )
+    open_file.assert_has_calls(
+        [
+            call("--filename--"),
+            call("orig"),
+        ]
+    )
+    resize_img.assert_called_once_with(file=file, target_dimensions=(350, 350))
+    img.save.assert_called_once_with(sized_file, format="JPEG")
+    save_file.assert_called_once_with("--filename--", sized_file)
+
+    # if original file is not found error bubbles up
+    open_file.side_effect = FileNotFoundError
+    with pytest.raises(FileNotFoundError):
+        utils.get_or_create_sized_image(
+            "orig",
+            (350, 350),
+            "-prefix-",
+        )

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -160,7 +160,7 @@ def get_crop_values(
 
 def get_filename_for_image_size(original_filename: str, prefix: str):
     head, tail = os.path.split(original_filename)
-    return f"{head}{prefix}{tail}"
+    return f"{head}/{prefix}/{tail}"
 
 
 def get_dimensions_and_prefix_from_standard_size(

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -17,7 +17,7 @@ from profiles.types import (
 
 def get_or_create_sized_image(
     original_filename: str, size: ImageDimensions, prefix: str
-):
+) -> File:
     filename = get_filename_for_image_size(original_filename, prefix)
 
     try:
@@ -28,7 +28,9 @@ def get_or_create_sized_image(
         image = resize_image(file=original_file, target_dimensions=size)
         file = BytesIO()
         image.save(file, format="JPEG")
+        file.seek(0)
         save_file_to_storages(filename, file)
+        file = open_file_from_storages(filename)
     return file
 
 

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -169,8 +169,8 @@ def get_dimensions_and_prefix_from_standard_size(
     return (standard_size.dimensions, standard_size.prefix)
 
 
-def get_storage_instance():
-    return storages.create_storage(storages.backends["default"])
+def get_storage_instance(backend:str="default"):
+    return storages.create_storage(storages.backends[backend])
 
 
 def get_file_from_storages(filename):

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -125,11 +125,22 @@ def get_crop_values(
             FocusPointOption.TOP_RIGHT,
         ):
             left = amount_to_remove
-        elif type(focus_point) == Point:
+        else:
+            if type(focus_point) not in (Point, tuple, ):
+                raise TypeError("focus_point is not FocusPointOption or Point")
+
             x, _ = focus_point  # type: ignore
+            if x > orig_width:
+                raise ValueError("Focus point value must be within image dimensions")
+
             amount_to_keep = orig_width - amount_to_remove
-            left = min(int(x - (amount_to_keep / 2)), 0)
-            right = orig_width - (amount_to_remove - left)
+            midpoint = int(amount_to_keep / 2)
+            left = x - midpoint
+            if left <= 0:
+                left = 0
+            elif (left + amount_to_keep) > orig_height:
+                left = amount_to_remove
+            right = orig_height - (amount_to_remove - left)
     elif dimension == Dimension.HEIGHT:
         if focus_point in (
             FocusPointOption.BOTTOM_LEFT,
@@ -150,11 +161,22 @@ def get_crop_values(
             FocusPointOption.TOP_RIGHT,
         ):
             bottom = orig_height - amount_to_remove
-        elif type(focus_point) == Point:
+        else:
+            if type(focus_point) not in (Point, tuple, ):
+                raise TypeError("focus_point is not FocusPointOption or Point")
+
             _, y = focus_point  # type: ignore
+            if y > orig_height:
+                raise ValueError("Focus point value must be within image dimensions")
+
             amount_to_keep = orig_height - amount_to_remove
-            top = min(int(y - (amount_to_keep / 2)), 0)
-            bottom = orig_height - (amount_to_remove - bottom)
+            midpoint = int(amount_to_keep / 2)
+            top = y - midpoint
+            if top <= 0:
+                top = 0
+            elif (top + amount_to_keep) > orig_height:
+                top = amount_to_remove
+            bottom = orig_height - (amount_to_remove - top)
     return (left, top, right, bottom)
 
 


### PR DESCRIPTION
NB although the change set mainly has test, please also review the function under test, they were added as part of #143 but not reviewed properly then due to the refactor work being time critical.

Mainly this adds a lot of utility for image resizing. The API for the utility is broader than the supported functionality; for example we will likely only ever need CROP type image resizing (as opposed to FILL or SQUASH/DEFORM) and no upscaling is currently allowed. The types and interfaces were added in case this grows in future.

The resizing is wired into the GET photo endpoint and currently happens on demand; when an image is requested it is resized to the requested size, saves in storages and returned. There's a ticket to optimise this for standard sizes.

<!--
Please ensure that you have:
- Referenced the JIRA ticket in the PR title
- Made sure the PR title is clear and concise as a commit message on `main`
- Put all relevant detail in this description area

And also that:
- Tests are up to date
- Documentation is up to date
-->
